### PR TITLE
Enable Windows auth sign in

### DIFF
--- a/Client/Pages/Users/Login.razor
+++ b/Client/Pages/Users/Login.razor
@@ -51,6 +51,19 @@ else
     private bool isLoading = true;
     bool passwordVisible = true;
 
+    protected override async Task OnInitializedAsync()
+    {
+        var current = await UserService.GetCurrentUser();
+        if (current != null)
+        {
+            await CookieHelper.LoginUser(current.UserName);
+            var uri = new Uri(NavigationManager.Uri);
+            var returnUrl = uri.Query.Contains("returnUrl") ? uri.Query.Substring(uri.Query.IndexOf("returnUrl") + 10) : "/";
+            returnUrl = Uri.UnescapeDataString(returnUrl);
+            NavigationManager.NavigateTo(returnUrl, true);
+        }
+    }
+
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (firstRender)

--- a/Client/Services/UserServiceProxy.cs
+++ b/Client/Services/UserServiceProxy.cs
@@ -34,5 +34,17 @@ namespace DynamicFormsApp.Client.Services
             var encoded = System.Net.WebUtility.UrlEncode(term);
             return await _httpClient.GetFromJsonAsync<List<UserModel>>($"api/user/search?term={encoded}");
         }
+
+        public async Task<UserModel?> GetCurrentUser()
+        {
+            try
+            {
+                return await _httpClient.GetFromJsonAsync<UserModel>("api/user/current");
+            }
+            catch
+            {
+                return null;
+            }
+        }
     }
 }

--- a/NdaProcesses.Shared/Services/IUserService.cs
+++ b/NdaProcesses.Shared/Services/IUserService.cs
@@ -13,5 +13,6 @@ namespace DynamicFormsApp.Shared.Services
         Task<UserModel> GetUserData(string userName);
         Task<List<UserModel>> GetAllUsers();
         Task<List<UserModel>> SearchUsers(string term);
+        Task<UserModel?> GetCurrentUser();
     }
 }

--- a/Server/Controllers/UserController.cs
+++ b/Server/Controllers/UserController.cs
@@ -48,5 +48,16 @@ namespace DynamicFormsApp.Server.Controllers
             var users = await _userService.SearchUsers(term ?? string.Empty);
             return Ok(users);
         }
+
+        [HttpGet("current")]
+        public async Task<ActionResult<UserModel>> Current()
+        {
+            var user = await _userService.GetCurrentUser();
+            if (user == null)
+            {
+                return Unauthorized();
+            }
+            return Ok(user);
+        }
     }
 }

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -6,6 +6,7 @@ using DynamicFormsApp.Server.Services;
 using DynamicFormsApp.Server.Data;
 using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Server.IISIntegration;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -43,6 +44,9 @@ builder.Services.AddScoped<IUserService, UserService>();
 builder.Services.AddScoped<CookieHelper>();
 builder.Services.AddScoped<IEmailService, EmailService>();
 
+builder.Services.AddAuthentication(IISDefaults.AuthenticationScheme);
+builder.Services.AddAuthorization();
+
 builder.Services.AddControllers();
 builder.Services.AddRadzenComponents();
 builder.Services.AddHttpClient();
@@ -64,6 +68,8 @@ else
 }
 
 app.UseHttpsRedirection();
+app.UseAuthentication();
+app.UseAuthorization();
 app.UseResponseCompression();
 app.MapControllers();
 app.UseStaticFiles();

--- a/Server/Services/UserService.cs
+++ b/Server/Services/UserService.cs
@@ -2,16 +2,19 @@ using DynamicFormsApp.Shared.Services;
 using DynamicFormsApp.Shared.Models;
 using System.DirectoryServices;
 using System.Linq;
+using Microsoft.AspNetCore.Http;
 
 namespace DynamicFormsApp.Server.Services
 {
     public class UserService : IUserService
     {
         private readonly IConfiguration _configuration;
+        private readonly IHttpContextAccessor _httpContextAccessor;
 
-        public UserService(IConfiguration configuration)
+        public UserService(IConfiguration configuration, IHttpContextAccessor httpContextAccessor)
         {
             _configuration = configuration;
+            _httpContextAccessor = httpContextAccessor;
         }
 
         public async Task<bool> ValidateUser(UserModel user)
@@ -203,6 +206,17 @@ namespace DynamicFormsApp.Server.Services
             }
 
             return list.OrderBy(u => u.DisplayName).ToList();
+        }
+
+        public async Task<UserModel?> GetCurrentUser()
+        {
+            var domainUser = _httpContextAccessor.HttpContext?.User?.Identity?.Name;
+            if (string.IsNullOrEmpty(domainUser))
+            {
+                return null;
+            }
+            var userName = domainUser.Contains("\\") ? domainUser.Split('\\')[1] : domainUser;
+            return await GetUserData(userName);
         }
 
     }


### PR DESCRIPTION
## Summary
- support retrieving currently logged-in domain user via new `GetCurrentUser` API
- check for Windows user on login page for automatic login
- register Windows authentication middleware for IIS hosting

## Testing
- `dotnet build DynamicFormsApp.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_687a801035888329b9f7eeb61cca25fa