### PR TITLE
Add integrated Windows auth login

### DIFF
--- a/Client/Pages/Users/Login.razor
+++ b/Client/Pages/Users/Login.razor
@@ -51,6 +51,16 @@ else
     private bool isLoading = true;
     bool passwordVisible = true;
 
+    protected override async Task OnInitializedAsync()
+    {
+        var name = await UserService.GetCurrentUserName();
+        if (!string.IsNullOrEmpty(name))
+        {
+            await CookieHelper.LoginUser(name);
+            NavigationManager.NavigateTo("/", true);
+        }
+    }
+
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (firstRender)

--- a/Client/Services/UserServiceProxy.cs
+++ b/Client/Services/UserServiceProxy.cs
@@ -34,5 +34,17 @@ namespace DynamicFormsApp.Client.Services
             var encoded = System.Net.WebUtility.UrlEncode(term);
             return await _httpClient.GetFromJsonAsync<List<UserModel>>($"api/user/search?term={encoded}");
         }
+
+        public async Task<string?> GetCurrentUserName()
+        {
+            try
+            {
+                return await _httpClient.GetFromJsonAsync<string>("api/user/current");
+            }
+            catch (HttpRequestException)
+            {
+                return null;
+            }
+        }
     }
 }

--- a/NdaProcesses.Shared/Services/IUserService.cs
+++ b/NdaProcesses.Shared/Services/IUserService.cs
@@ -13,5 +13,6 @@ namespace DynamicFormsApp.Shared.Services
         Task<UserModel> GetUserData(string userName);
         Task<List<UserModel>> GetAllUsers();
         Task<List<UserModel>> SearchUsers(string term);
+        Task<string?> GetCurrentUserName();
     }
 }

--- a/Server/Controllers/UserController.cs
+++ b/Server/Controllers/UserController.cs
@@ -48,5 +48,13 @@ namespace DynamicFormsApp.Server.Controllers
             var users = await _userService.SearchUsers(term ?? string.Empty);
             return Ok(users);
         }
+
+        [HttpGet("current")]
+        public async Task<ActionResult<string>> GetCurrentUserName()
+        {
+            var name = await _userService.GetCurrentUserName();
+            if (string.IsNullOrEmpty(name)) return NotFound();
+            return Ok(name);
+        }
     }
 }

--- a/Server/DynamicFormsApp.Server.csproj
+++ b/Server/DynamicFormsApp.Server.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Radzen.Blazor" Version="*" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.0" />
     <PackageReference Include="System.DirectoryServices" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="8.0.0" />
     <ProjectReference Include="..\Client\DynamicFormsApp.Client.csproj" />
     <ProjectReference Include="..\NdaProcesses.Shared\DynamicFormsApp.Shared.csproj" />
   </ItemGroup>

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -6,6 +6,7 @@ using DynamicFormsApp.Server.Services;
 using DynamicFormsApp.Server.Data;
 using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Authentication.Negotiate;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -47,6 +48,12 @@ builder.Services.AddControllers();
 builder.Services.AddRadzenComponents();
 builder.Services.AddHttpClient();
 builder.Services.AddHttpContextAccessor();
+builder.Services.AddAuthentication(NegotiateDefaults.AuthenticationScheme)
+       .AddNegotiate();
+builder.Services.AddAuthorization(options =>
+{
+    options.FallbackPolicy = options.DefaultPolicy;
+});
 builder.Services.AddControllersWithViews();
 builder.Services.AddRazorPages();
 var app = builder.Build();
@@ -65,10 +72,12 @@ else
 
 app.UseHttpsRedirection();
 app.UseResponseCompression();
-app.MapControllers();
+app.UseAuthentication();
+app.UseAuthorization();
 app.UseStaticFiles();
 app.UseAntiforgery();
 app.UseCors("AllowAll");
+app.MapControllers();
 
 // Configure Blazor components (server and WebAssembly rendering)
 app.MapRazorComponents<App>()

--- a/Server/Services/UserService.cs
+++ b/Server/Services/UserService.cs
@@ -2,16 +2,19 @@ using DynamicFormsApp.Shared.Services;
 using DynamicFormsApp.Shared.Models;
 using System.DirectoryServices;
 using System.Linq;
+using Microsoft.AspNetCore.Http;
 
 namespace DynamicFormsApp.Server.Services
 {
     public class UserService : IUserService
     {
         private readonly IConfiguration _configuration;
+        private readonly IHttpContextAccessor _httpContextAccessor;
 
-        public UserService(IConfiguration configuration)
+        public UserService(IConfiguration configuration, IHttpContextAccessor httpContextAccessor)
         {
             _configuration = configuration;
+            _httpContextAccessor = httpContextAccessor;
         }
 
         public async Task<bool> ValidateUser(UserModel user)
@@ -203,6 +206,12 @@ namespace DynamicFormsApp.Server.Services
             }
 
             return list.OrderBy(u => u.DisplayName).ToList();
+        }
+
+        public Task<string?> GetCurrentUserName()
+        {
+            var name = _httpContextAccessor.HttpContext?.User?.Identity?.Name;
+            return Task.FromResult(name);
         }
 
     }


### PR DESCRIPTION
## Summary
- enable Windows authentication on the server using Negotiate
- expose API endpoint for current user name
- add `GetCurrentUserName` method to user service and proxy
- auto-login on the client when a Windows username is provided

## Testing
- `dotnet restore`
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_687f715d6ed08329b57f3bbf7ebf3b9b