### PR TITLE
Enable Windows authentication auto-login

### DIFF
--- a/Client/Layout/MainLayout.razor
+++ b/Client/Layout/MainLayout.razor
@@ -100,7 +100,7 @@
 @code {
     private bool sidebarExpanded = true;
     private string sidebarToggleIcon => sidebarExpanded ? "keyboard_arrow_left" : "keyboard_arrow_right";
-    private UserModel ValidUser;
+    private UserModel? ValidUser;
     private string username;
     private EmailModel email = new EmailModel();
     private bool waitingforuserload = false;
@@ -225,7 +225,7 @@
         else
         {
             ValidUser = await UserService.GetUserData(userId);
-            username = ValidUser.DisplayName;
+            username = ValidUser?.DisplayName;
         }
         waitingforuserload = true; // Mark the user data as loaded
     }

--- a/Client/Layout/MainLayout.razor
+++ b/Client/Layout/MainLayout.razor
@@ -210,6 +210,16 @@
         string userId = await CookieHelper.LoginStatus();
         if (string.IsNullOrEmpty(userId))
         {
+            var current = await UserService.GetCurrentUserName();
+            if (!string.IsNullOrEmpty(current))
+            {
+                await CookieHelper.LoginUser(current);
+                userId = current;
+            }
+        }
+
+        if (string.IsNullOrEmpty(userId))
+        {
             username = null;
         }
         else

--- a/Client/Pages/BugTextDialog.razor
+++ b/Client/Pages/BugTextDialog.razor
@@ -80,7 +80,7 @@
 
     string BugDescriptionText { get; set; } = string.Empty;
     private string username;
-    private UserModel ValidUser;
+    private UserModel? ValidUser;
     List<EmailAttachment> Attachments { get; set; } = new();
     private bool waitingforuserload = false;
 
@@ -122,7 +122,7 @@
         else
         {
             ValidUser = await UserService.GetUserData(userId);
-            username = ValidUser.DisplayName;
+            username = ValidUser?.DisplayName;
         }
         waitingforuserload = true; // Mark the user data as loaded
     }

--- a/Client/Services/UserServiceProxy.cs
+++ b/Client/Services/UserServiceProxy.cs
@@ -19,9 +19,14 @@ namespace DynamicFormsApp.Client.Services
             return await response.Content.ReadFromJsonAsync<bool>();
         }
 
-        public async Task<UserModel> GetUserData(string userName)
+        public async Task<UserModel?> GetUserData(string userName)
         {
-            return await _httpClient.GetFromJsonAsync<UserModel>($"api/user/{userName}");
+            var response = await _httpClient.GetAsync($"api/user/{userName}");
+            if (!response.IsSuccessStatusCode)
+            {
+                return null;
+            }
+            return await response.Content.ReadFromJsonAsync<UserModel>();
         }
 
         public async Task<string?> GetCurrentUserName()

--- a/Client/Services/UserServiceProxy.cs
+++ b/Client/Services/UserServiceProxy.cs
@@ -24,6 +24,16 @@ namespace DynamicFormsApp.Client.Services
             return await _httpClient.GetFromJsonAsync<UserModel>($"api/user/{userName}");
         }
 
+        public async Task<string?> GetCurrentUserName()
+        {
+            var response = await _httpClient.GetAsync("api/user/current");
+            if (!response.IsSuccessStatusCode)
+            {
+                return null;
+            }
+            return await response.Content.ReadAsStringAsync();
+        }
+
         public async Task<List<UserModel>> GetAllUsers()
         {
             return await _httpClient.GetFromJsonAsync<List<UserModel>>("api/user/list");

--- a/NdaProcesses.Shared/Services/IUserService.cs
+++ b/NdaProcesses.Shared/Services/IUserService.cs
@@ -11,6 +11,7 @@ namespace DynamicFormsApp.Shared.Services
     {
         Task<bool> ValidateUser(UserModel user);
         Task<UserModel> GetUserData(string userName);
+        Task<string?> GetCurrentUserName();
         Task<List<UserModel>> GetAllUsers();
         Task<List<UserModel>> SearchUsers(string term);
     }

--- a/NdaProcesses.Shared/Services/IUserService.cs
+++ b/NdaProcesses.Shared/Services/IUserService.cs
@@ -10,7 +10,7 @@ namespace DynamicFormsApp.Shared.Services
     public interface IUserService
     {
         Task<bool> ValidateUser(UserModel user);
-        Task<UserModel> GetUserData(string userName);
+        Task<UserModel?> GetUserData(string userName);
         Task<string?> GetCurrentUserName();
         Task<List<UserModel>> GetAllUsers();
         Task<List<UserModel>> SearchUsers(string term);

--- a/Server/Controllers/UserController.cs
+++ b/Server/Controllers/UserController.cs
@@ -22,6 +22,17 @@ namespace DynamicFormsApp.Server.Controllers
             return await _userService.ValidateUser(user);
         }
 
+        [HttpGet("current")]
+        public async Task<ActionResult<string>> GetCurrentUserName()
+        {
+            var name = await _userService.GetCurrentUserName();
+            if (string.IsNullOrEmpty(name))
+            {
+                return Unauthorized();
+            }
+            return Ok(name);
+        }
+
 
         [HttpGet("{userName}")]
         public async Task<ActionResult<UserModel>> GetUserData(string userName)

--- a/Server/DynamicFormsApp.Server.csproj
+++ b/Server/DynamicFormsApp.Server.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Radzen.Blazor" Version="*" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.0" />
     <PackageReference Include="System.DirectoryServices" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="8.0.0" />
     <ProjectReference Include="..\Client\DynamicFormsApp.Client.csproj" />
     <ProjectReference Include="..\NdaProcesses.Shared\DynamicFormsApp.Shared.csproj" />
   </ItemGroup>

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -5,6 +5,7 @@ using DynamicFormsApp.Shared.Services;
 using DynamicFormsApp.Server.Services;
 using DynamicFormsApp.Server.Data;
 using Microsoft.AspNetCore.ResponseCompression;
+using Microsoft.AspNetCore.Authentication.Negotiate;
 using Microsoft.EntityFrameworkCore;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -47,6 +48,12 @@ builder.Services.AddControllers();
 builder.Services.AddRadzenComponents();
 builder.Services.AddHttpClient();
 builder.Services.AddHttpContextAccessor();
+builder.Services.AddAuthentication(NegotiateDefaults.AuthenticationScheme)
+       .AddNegotiate();
+builder.Services.AddAuthorization(options =>
+{
+    options.FallbackPolicy = options.DefaultPolicy;
+});
 builder.Services.AddControllersWithViews();
 builder.Services.AddRazorPages();
 var app = builder.Build();
@@ -69,6 +76,8 @@ app.MapControllers();
 app.UseStaticFiles();
 app.UseAntiforgery();
 app.UseCors("AllowAll");
+app.UseAuthentication();
+app.UseAuthorization();
 
 // Configure Blazor components (server and WebAssembly rendering)
 app.MapRazorComponents<App>()

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -72,12 +72,12 @@ else
 
 app.UseHttpsRedirection();
 app.UseResponseCompression();
-app.MapControllers();
 app.UseStaticFiles();
 app.UseAntiforgery();
 app.UseCors("AllowAll");
 app.UseAuthentication();
 app.UseAuthorization();
+app.MapControllers();
 
 // Configure Blazor components (server and WebAssembly rendering)
 app.MapRazorComponents<App>()

--- a/Server/Properties/launchSettings.json
+++ b/Server/Properties/launchSettings.json
@@ -1,7 +1,7 @@
 {
   "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
+    "windowsAuthentication": true,
+    "anonymousAuthentication": false,
     "iisExpress": {
       "applicationUrl": "http://localhost:19712",
       "sslPort": 44395

--- a/Server/Services/UserService.cs
+++ b/Server/Services/UserService.cs
@@ -44,7 +44,7 @@ namespace DynamicFormsApp.Server.Services
             }
         }
 
-        public async Task<UserModel> GetUserData(string userName)
+        public async Task<UserModel?> GetUserData(string userName)
         {
             try
             {
@@ -110,6 +110,10 @@ namespace DynamicFormsApp.Server.Services
         public Task<string?> GetCurrentUserName()
         {
             var name = _httpContextAccessor.HttpContext?.User?.Identity?.Name;
+            if (!string.IsNullOrEmpty(name) && name.Contains("\\"))
+            {
+                name = name.Split('\x5c').Last();
+            }
             return Task.FromResult<string?>(name);
         }
 

--- a/Server/Services/UserService.cs
+++ b/Server/Services/UserService.cs
@@ -8,10 +8,12 @@ namespace DynamicFormsApp.Server.Services
     public class UserService : IUserService
     {
         private readonly IConfiguration _configuration;
+        private readonly IHttpContextAccessor _httpContextAccessor;
 
-        public UserService(IConfiguration configuration)
+        public UserService(IConfiguration configuration, IHttpContextAccessor httpContextAccessor)
         {
             _configuration = configuration;
+            _httpContextAccessor = httpContextAccessor;
         }
 
         public async Task<bool> ValidateUser(UserModel user)
@@ -103,6 +105,12 @@ namespace DynamicFormsApp.Server.Services
                 Console.WriteLine($"An error occurred: {ex.Message}");
                 return null;
             }
+        }
+
+        public Task<string?> GetCurrentUserName()
+        {
+            var name = _httpContextAccessor.HttpContext?.User?.Identity?.Name;
+            return Task.FromResult<string?>(name);
         }
 
         static string ExtractNameFromDN(string distinguishedName)


### PR DESCRIPTION
## Summary
- add method for retrieving current Windows user
- enable Negotiate auth in `Server/Program.cs`
- update user services and controller for auto-login
- tweak layout to automatically use Windows username when no cookie

## Testing
- `dotnet restore`
- `dotnet build --no-restore`


------
https://chatgpt.com/codex/tasks/task_e_687f715d6ed08329b57f3bbf7ebf3b9b