### PR TITLE
Allow IT admins to give reason for deletion

### DIFF
--- a/Client/Pages/DynamicForms/DeleteFormDialog.razor
+++ b/Client/Pages/DynamicForms/DeleteFormDialog.razor
@@ -1,0 +1,34 @@
+@inject DialogService DialogService
+@inject NotificationService NotificationService
+
+<RadzenCard Style="width:100%;max-width:400px">
+    <div class="mb-3">
+        <label class="form-label">Reason for deleting '@FormName'</label>
+        <RadzenTextArea @bind-Value="reason" Style="width:100%" Rows="3" />
+    </div>
+    <div class="d-flex justify-content-end">
+        <RadzenButton Text="Cancel" ButtonStyle="ButtonStyle.Secondary" Click="@(() => DialogService.Close(null))" class="me-2" />
+        <RadzenButton Text="Delete" ButtonStyle="ButtonStyle.Danger" Click="Confirm" Disabled="@string.IsNullOrWhiteSpace(reason)" />
+    </div>
+</RadzenCard>
+
+@code {
+    [Parameter] public string FormName { get; set; } = string.Empty;
+
+    private string reason = string.Empty;
+
+    void Confirm()
+    {
+        if (string.IsNullOrWhiteSpace(reason))
+        {
+            NotificationService.Notify(new NotificationMessage
+            {
+                Severity = NotificationSeverity.Warning,
+                Summary = "Reason required",
+                Detail = "Please provide a reason"
+            });
+            return;
+        }
+        DialogService.Close(reason);
+    }
+}

--- a/Client/Pages/DynamicForms/DeletedFormsAdmin.razor
+++ b/Client/Pages/DynamicForms/DeletedFormsAdmin.razor
@@ -6,17 +6,30 @@
 @inject CookieHelper CookieHelper
 @inject IUserService UserService
 
-<h3>Deleted Forms</h3>
+<h3>Admin Forms</h3>
+
+<ul class="nav nav-tabs mb-3">
+    <li class="nav-item">
+        <a class='nav-link @(activeTab == "deleted" ? "active" : null)' href="#" @onclick='() => SetTab("deleted")' @onclick:preventDefault>Deleted Forms</a>
+    </li>
+    <li class="nav-item">
+        <a class='nav-link @(activeTab == "inactive" ? "active" : null)' href="#" @onclick='() => SetTab("inactive")' @onclick:preventDefault>Unpublished Forms</a>
+    </li>
+</ul>
 
 <input class="form-control mb-3" placeholder="Search..." @bind="searchTerm" />
 
-@if (forms == null)
+@if (forms == null || inactiveForms == null)
 {
     <p>Loading...</p>
 }
-else if (!FilteredForms.Any())
+else if (activeTab == "deleted" && !FilteredForms.Any())
 {
     <p>No deleted forms found.</p>
+}
+else if (activeTab == "inactive" && !FilteredInactive.Any())
+{
+    <p>No unpublished forms found.</p>
 }
 else
 {
@@ -31,17 +44,35 @@ else
                 </tr>
             </thead>
             <tbody>
-                @foreach (var f in FilteredForms)
+                @if (activeTab == "deleted")
                 {
-                    <tr>
-                        <td>@f.Name</td>
-                        <td>@f.Description</td>
-                        <td>@f.CreatedBy</td>
-                        <td>
-                            <button class="btn btn-sm btn-primary me-2" @onclick="() => Restore(f.Id)">Restore</button>
-                            <a class="btn btn-sm btn-secondary" href="@($"/forms/{f.Id}/edit")">Edit</a>
-                        </td>
-                    </tr>
+                    @foreach (var f in FilteredForms)
+                    {
+                        <tr>
+                            <td>@f.Name</td>
+                            <td>@f.Description</td>
+                            <td>@f.CreatedBy</td>
+                            <td>
+                                <button class="btn btn-sm btn-primary me-2" @onclick="() => Restore(f.Id)">Restore</button>
+                                <a class="btn btn-sm btn-secondary" href="@($"/forms/{f.Id}/edit")">Edit</a>
+                            </td>
+                        </tr>
+                    }
+                }
+                else
+                {
+                    @foreach (var f in FilteredInactive)
+                    {
+                        <tr>
+                            <td>@f.Name</td>
+                            <td>@f.Description</td>
+                            <td>@f.CreatedBy</td>
+                            <td>
+                                <button class="btn btn-sm btn-primary me-2" @onclick="() => Publish(f.Id)">Publish</button>
+                                <a class="btn btn-sm btn-secondary" href="@($"/forms/{f.Id}/edit")">Edit</a>
+                            </td>
+                        </tr>
+                    }
                 }
             </tbody>
         </table>
@@ -50,11 +81,21 @@ else
 
 @code {
     private List<Form>? forms;
+    private List<Form>? inactiveForms;
     private string searchTerm = string.Empty;
+    private string activeTab = "deleted";
 
     private IEnumerable<Form> FilteredForms => string.IsNullOrWhiteSpace(searchTerm)
         ? forms ?? Enumerable.Empty<Form>()
         : forms?.Where(f =>
+            (f.Name?.Contains(searchTerm, StringComparison.OrdinalIgnoreCase) ?? false) ||
+            (f.Description?.Contains(searchTerm, StringComparison.OrdinalIgnoreCase) ?? false) ||
+            (f.CreatedBy?.Contains(searchTerm, StringComparison.OrdinalIgnoreCase) ?? false))
+            ?? Enumerable.Empty<Form>();
+
+    private IEnumerable<Form> FilteredInactive => string.IsNullOrWhiteSpace(searchTerm)
+        ? inactiveForms ?? Enumerable.Empty<Form>()
+        : inactiveForms?.Where(f =>
             (f.Name?.Contains(searchTerm, StringComparison.OrdinalIgnoreCase) ?? false) ||
             (f.Description?.Contains(searchTerm, StringComparison.OrdinalIgnoreCase) ?? false) ||
             (f.CreatedBy?.Contains(searchTerm, StringComparison.OrdinalIgnoreCase) ?? false))
@@ -82,18 +123,51 @@ else
             forms = (await Http.GetFromJsonAsync<List<Form>>("api/forms/deleted"))
                 ?.Where(f => !f.IsDraft)
                 .ToList();
+            inactiveForms = (await Http.GetFromJsonAsync<List<Form>>("api/forms/inactive"))
+                ?.Where(f => !f.IsDraft)
+                .ToList();
             StateHasChanged();
         }
     }
 
     private async Task Restore(int id)
     {
-        await Http.PostAsync($"api/forms/{id}/restore", null);
         var item = forms?.FirstOrDefault(f => f.Id == id);
-        if (item != null)
-        {
-            forms!.Remove(item);
-        }
+        if (item == null)
+            return;
+
+        bool? confirm = await DialogService.Confirm(
+            $"Are you sure you want to restore '{item.Name}' {item.Description}?",
+            "Restore Form",
+            new ConfirmOptions { OkButtonText = "Yes", CancelButtonText = "No" });
+        if (confirm != true)
+            return;
+
+        await Http.PostAsync($"api/forms/{id}/restore", null);
+        forms!.Remove(item);
         StateHasChanged();
+    }
+
+    private async Task Publish(int id)
+    {
+        var item = inactiveForms?.FirstOrDefault(f => f.Id == id);
+        if (item == null)
+            return;
+
+        bool? confirm = await DialogService.Confirm(
+            $"Are you sure you want to publish '{item.Name}' {item.Description}?",
+            "Publish Form",
+            new ConfirmOptions { OkButtonText = "Yes", CancelButtonText = "No" });
+        if (confirm != true)
+            return;
+
+        await Http.PostAsync($"api/forms/{id}/publish", null);
+        inactiveForms!.Remove(item);
+        StateHasChanged();
+    }
+
+    private void SetTab(string tab)
+    {
+        activeTab = tab;
     }
 }

--- a/Client/Pages/DynamicForms/FormDesigner.razor
+++ b/Client/Pages/DynamicForms/FormDesigner.razor
@@ -260,7 +260,15 @@
         {
             var wrapper = await resp.Content.ReadFromJsonAsync<JsonElement>();
             int newId = wrapper.GetProperty("formId").GetInt32();
-            Navigation.NavigateTo($"/forms/{newId}");
+            var link = $"{Navigation.BaseUri.TrimEnd('/')}/forms/{newId}";
+            await JS.InvokeVoidAsync("copyText", link);
+            NotificationService.Notify(new NotificationMessage
+            {
+                Severity = NotificationSeverity.Success,
+                Summary = "Form Created",
+                Detail = "Link copied to clipboard."
+            });
+            Navigation.NavigateTo("/forms");
         }
         else
         {

--- a/Client/Pages/DynamicForms/Index.razor
+++ b/Client/Pages/DynamicForms/Index.razor
@@ -356,8 +356,16 @@ else
         {
             var wrapper = await resp.Content.ReadFromJsonAsync<JsonElement>();
             int newId = wrapper.GetProperty("formId").GetInt32();
+            var link = $"{Navigation.BaseUri.TrimEnd('/')}/forms/{newId}";
+            await JS.InvokeVoidAsync("copyText", link);
+            NotificationService.Notify(new NotificationMessage
+            {
+                Severity = NotificationSeverity.Success,
+                Summary = "Form Created",
+                Detail = "Link copied to clipboard."
+            });
             ignoreNavigationPrompt = true;
-            Navigation.NavigateTo($"/forms/{newId}");
+            Navigation.NavigateTo("/forms");
         }
     }
 

--- a/Client/Pages/DynamicForms/SearchForms.razor
+++ b/Client/Pages/DynamicForms/SearchForms.razor
@@ -44,6 +44,9 @@ else
                         {
                             <td>
                                 <button class="btn btn-sm btn-outline-secondary me-2" @onclick="() => ChangeOwner(f.Id)">Change Owner</button>
+                                <button class="btn btn-sm btn-danger" @onclick="() => DeleteForm(f.Id)" title="Delete Form">
+                                    <span class="material-icons">delete</span>
+                                </button>
                             </td>
                         }
                         <td>
@@ -96,5 +99,37 @@ else
             forms = await Http.GetFromJsonAsync<List<Form>>($"api/forms/search?includePrivate={includePrivate}");
             StateHasChanged();
         }
+    }
+
+    private async Task DeleteForm(int id)
+    {
+        var item = forms?.FirstOrDefault(f => f.Id == id);
+        if (item == null)
+        {
+            return;
+        }
+
+        var parameters = new Dictionary<string, object>
+        {
+            ["FormName"] = item.Name
+        };
+        var result = await DialogService.OpenAsync<DeleteFormDialog>(
+            "Delete Form", parameters, new DialogOptions { Width = "400px" });
+        if (result is not string reason || string.IsNullOrWhiteSpace(reason))
+        {
+            return;
+        }
+
+        var encoded = Uri.EscapeDataString(reason);
+        var request = new HttpRequestMessage(HttpMethod.Delete, $"api/forms/{id}?reason={encoded}");
+        await Http.SendAsync(request);
+        forms!.Remove(item);
+        NotificationService.Notify(new NotificationMessage
+        {
+            Severity = NotificationSeverity.Success,
+            Summary = "Form Deleted",
+            Detail = item.Name
+        });
+        StateHasChanged();
     }
 }

--- a/Client/Services/EmailServiceProxy.cs
+++ b/Client/Services/EmailServiceProxy.cs
@@ -37,5 +37,11 @@ namespace DynamicFormsApp.Client.Services
             var payload = new { toEmail, formName, description, formId, transferredBy };
             await _httpClient.PostAsJsonAsync("api/email/formtransfer", payload);
         }
+
+        public async Task SendFormDeletedNotification(string toEmail, string formName, string? description, string deletedBy, string reason)
+        {
+            var payload = new { toEmail, formName, description, deletedBy, reason };
+            await _httpClient.PostAsJsonAsync("api/email/formdeleted", payload);
+        }
     }
 }

--- a/NdaProcesses.Shared/Services/IEmailService.cs
+++ b/NdaProcesses.Shared/Services/IEmailService.cs
@@ -9,5 +9,6 @@ namespace DynamicFormsApp.Shared.Services
         Task SendFormResponseNotification(string toEmail, string formName, int formId);
         Task SendFormShareNotification(string toEmail, string firstName, string formName, string? description, int formId, string sharedBy, string ownerEmail);
         Task SendFormTransferNotification(string toEmail, string formName, string? description, int formId, string transferredBy);
+        Task SendFormDeletedNotification(string toEmail, string formName, string? description, string deletedBy, string reason);
     }
 }

--- a/README.md
+++ b/README.md
@@ -1,0 +1,47 @@
+# Dynamic Forms System
+
+The Dynamic Forms System lets employees create custom forms, share them with others and collect responses without coding. Use it through your browser; no extra software is required.
+
+## Key Features
+
+- **Form Builder**: Build forms with a drag‑and‑drop designer. Add text fields, multiple choice, checkboxes, dates, times, file uploads and more.
+- **Drafts**: Save a form as a draft and finish it later.
+- **Publish / Unpublish**: Control when a form is available for people to fill out. You can deactivate a form at any time.
+- **Response Collection**: View each submitted response or download them as CSV, PDF or Excel files. A summary view aggregates results for quick analysis.
+- **Sharing**: Share a form with coworkers so they can view responses. Transfer ownership when someone else should maintain the form.
+- **Search**: Search all published forms. IT staff can change form ownership if needed.
+- **Deleted and Unpublished Forms**: IT administrators can restore deleted forms or publish inactive forms from the Admin page.
+- **Form Deletion Notices**: Whenever a form is deleted, the owner receives an email. If an IT administrator deletes someone else's form, they must provide a reason and that reason is included in the email.
+
+## Typical Workflow
+
+1. **Log in** with your network account.
+2. Go to **"New Form"** and design your form. Give it a name and description, drag fields onto the canvas and arrange them in rows and columns.
+3. Click **Create Form** to publish it immediately, or choose **Save as Draft** if you are not ready.
+4. After publishing, open **My Forms** to see your forms. From here you can open the form, edit it, see responses, view a summary, share it or delete it. Use the toggle switch to publish or unpublish the form.
+5. When someone fills out your form, you will see their responses under **Responses**. Download the results or view each response individually. If you enabled email notifications, you will receive an email whenever a new response is submitted.
+6. **Draft Forms** lists all your drafts so you can continue editing or delete them.
+7. **Shared Forms** shows forms that others shared with you. You can view the responses and leave the form if you no longer need access.
+8. Use **Search Forms** to find forms by name, description or owner.
+9. **Admin Forms** (available to the Information Technology department) lets administrators restore deleted forms and publish unpublished forms.
+
+## Additional Notes
+
+- For forms that require sign‑in, users must log in before accessing them.
+- When you upload files through a form, they are stored on the server. PDFs and images can be previewed directly in the responses table.
+- If you encounter issues or have questions, please contact the IT department for assistance.
+
+## Hosting on IIS
+
+To host the Dynamic Forms System on a Windows server with IIS:
+
+1. **Install the ASP.NET Core Hosting Bundle** so IIS can run ASP.NET Core applications. The bundle includes the runtime and the IIS module.
+2. **Publish the server project**:
+
+   ```bash
+   dotnet publish Server/DynamicFormsApp.Server.csproj -c Release -o C:\DynamicFormsApp\publish
+   ```
+
+3. Copy the published folder to the server. In **IIS Manager**, create a new Web Site (or Application) that points to this folder and uses an Application Pool with **No Managed Code**. Enable WebSockets for the site.
+4. Update `appsettings.json` or environment variables with your connection strings and email settings. Set `ASPNETCORE_ENVIRONMENT` as needed.
+5. Start the site and browse to its URL to confirm the application loads.

--- a/Server/Components/App.razor
+++ b/Server/Components/App.razor
@@ -30,6 +30,7 @@
     <script src="js/dragdrop-wrapper.js"></script>
     <script src="js/chartInterop.js"></script>
     <script type="module" src="js/exportHelper.js"></script>
+    <script src="js/clipboardHelper.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>

--- a/Server/Controllers/EmailController.cs
+++ b/Server/Controllers/EmailController.cs
@@ -37,6 +37,13 @@ namespace DynamicFormsApp.Server.Controllers
             return Ok();
         }
 
+        [HttpPost("formdeleted")]
+        public async Task<IActionResult> SendFormDeletedEmail([FromBody] FormDeletedNotification model)
+        {
+            await _emailService.SendFormDeletedNotification(model.toEmail, model.formName, model.description, model.deletedBy, model.reason);
+            return Ok();
+        }
+
         public class FormResponseNotification
         {
             public string toEmail { get; set; }
@@ -53,6 +60,15 @@ namespace DynamicFormsApp.Server.Controllers
             public int formId { get; set; }
             public string sharedBy { get; set; }
             public string ownerEmail { get; set; }
+        }
+
+        public class FormDeletedNotification
+        {
+            public string toEmail { get; set; }
+            public string formName { get; set; }
+            public string? description { get; set; }
+            public string deletedBy { get; set; }
+            public string reason { get; set; }
         }
     }
 }

--- a/Server/Controllers/FormsController.cs
+++ b/Server/Controllers/FormsController.cs
@@ -201,16 +201,51 @@ namespace DynamicFormsApp.Server.Controllers
             return Ok(forms);
         }
 
-        // DELETE /api/forms/{id}
-        [HttpDelete("{id}")]
-        public async Task<IActionResult> Delete(int id)
+        [HttpGet("inactive")]
+        public async Task<ActionResult<IEnumerable<Form>>> GetInactive()
         {
             if (!Request.Cookies.TryGetValue("userName", out var user) || string.IsNullOrEmpty(user))
             {
                 return Unauthorized();
             }
 
-            await _svc.DeleteFormAsync(id, user);
+            var info = await _userSvc.GetUserData(user);
+            if (!string.Equals(info?.Department, "Information Technology", StringComparison.OrdinalIgnoreCase))
+            {
+                return Unauthorized();
+            }
+
+            var forms = await _svc.GetInactiveFormsAsync();
+            return Ok(forms);
+        }
+
+        // DELETE /api/forms/{id}
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete(int id, [FromQuery] string? reason)
+        {
+            if (!Request.Cookies.TryGetValue("userName", out var user) || string.IsNullOrEmpty(user))
+            {
+                return Unauthorized();
+            }
+
+            var form = await _svc.GetFormAsync(id);
+            var requester = await _userSvc.GetUserData(user);
+            bool isAdmin = string.Equals(requester?.Department, "Information Technology", StringComparison.OrdinalIgnoreCase);
+
+            if (!isAdmin && !string.Equals(form.CreatedBy, user, StringComparison.OrdinalIgnoreCase))
+            {
+                return Unauthorized();
+            }
+
+            await _svc.DeleteFormAsync(id, user, isAdmin);
+
+            var owner = await _userSvc.GetUserData(form.CreatedBy);
+            if (!string.IsNullOrEmpty(owner?.Email))
+            {
+                var deletedBy = requester?.DisplayName ?? user;
+                await _emailSvc.SendFormDeletedNotification(owner.Email, form.Name, form.Description, deletedBy, reason ?? string.Empty);
+            }
+
             return NoContent();
         }
 
@@ -235,6 +270,24 @@ namespace DynamicFormsApp.Server.Controllers
             }
 
             await _svc.ActivateFormAsync(id, user);
+            return NoContent();
+        }
+
+        [HttpPost("{id}/publish")]
+        public async Task<IActionResult> Publish(int id)
+        {
+            if (!Request.Cookies.TryGetValue("userName", out var user) || string.IsNullOrEmpty(user))
+            {
+                return Unauthorized();
+            }
+
+            var info = await _userSvc.GetUserData(user);
+            if (!string.Equals(info?.Department, "Information Technology", StringComparison.OrdinalIgnoreCase))
+            {
+                return Unauthorized();
+            }
+
+            await _svc.PublishFormAsync(id);
             return NoContent();
         }
 

--- a/Server/Services/DynamicFormService.cs
+++ b/Server/Services/DynamicFormService.cs
@@ -276,12 +276,17 @@ namespace DynamicFormsApp.Server.Services
             await _db.SaveChangesAsync();
         }
 
-        public async Task DeleteFormAsync(int formId, string user)
+        public async Task DeleteFormAsync(int formId, string user, bool isAdmin)
         {
-            var form = await _db.Forms.FirstOrDefaultAsync(f => f.Id == formId && f.CreatedBy == user);
+            var form = await _db.Forms.FirstOrDefaultAsync(f => f.Id == formId);
             if (form == null)
             {
                 throw new InvalidOperationException("Form not found");
+            }
+
+            if (!isAdmin && !string.Equals(form.CreatedBy, user, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException("Unauthorized");
             }
 
             form.IsDeleted = true;
@@ -327,6 +332,26 @@ namespace DynamicFormsApp.Server.Services
                 .Include(f => f.Fields)
                 .Where(f => f.IsDeleted && !f.IsDraft)
                 .ToListAsync();
+        }
+
+        public async Task<List<Form>> GetInactiveFormsAsync()
+        {
+            return await _db.Forms
+                .Include(f => f.Fields)
+                .Where(f => !f.IsActive && !f.IsDeleted && !f.IsDraft)
+                .ToListAsync();
+        }
+
+        public async Task PublishFormAsync(int formId)
+        {
+            var form = await _db.Forms.FirstOrDefaultAsync(f => f.Id == formId);
+            if (form == null)
+            {
+                throw new InvalidOperationException("Form not found");
+            }
+
+            form.IsActive = true;
+            await _db.SaveChangesAsync();
         }
 
         public async Task<int> GetFormCountAsync()

--- a/Server/Services/EmailService.cs
+++ b/Server/Services/EmailService.cs
@@ -138,5 +138,31 @@ namespace DynamicFormsApp.Server.Services
             };
             await client.SendMailAsync(mail);
         }
+
+        public async Task SendFormDeletedNotification(string toEmail, string formName, string? description, string deletedBy, string reason)
+        {
+            var descBlock = string.IsNullOrWhiteSpace(description) ? string.Empty : $"<p>{description}</p>";
+            var reasonBlock = string.IsNullOrWhiteSpace(reason) ? string.Empty : $"<p><strong>Reason:</strong> {reason}</p>";
+
+            var mail = new MailMessage
+            {
+                From = new MailAddress(_configuration["Email:From"] ?? "noreply@example.com"),
+                Subject = $"Your form '{formName}' was deleted",
+                Body = $@"<div style='font-family:sans-serif;font-size:14px;line-height:1.5'>
+                            <p>Your form <strong>{formName}</strong> was deleted by <strong>{deletedBy}</strong>.</p>
+                            {descBlock}
+                            {reasonBlock}
+                        </div>",
+                IsBodyHtml = true
+            };
+
+            mail.To.Add(toEmail);
+
+            using var client = new SmtpClient(_configuration["Email:IP"])
+            {
+                Port = int.Parse(_configuration["Email:Port"]!)
+            };
+            await client.SendMailAsync(mail);
+        }
     }
 }

--- a/Server/wwwroot/js/clipboardHelper.js
+++ b/Server/wwwroot/js/clipboardHelper.js
@@ -1,0 +1,12 @@
+window.copyText = (text) => {
+    if (navigator.clipboard) {
+        navigator.clipboard.writeText(text);
+    } else {
+        const temp = document.createElement('textarea');
+        temp.value = text;
+        document.body.appendChild(temp);
+        temp.select();
+        document.execCommand('copy');
+        document.body.removeChild(temp);
+    }
+};


### PR DESCRIPTION
## Summary
- add DeleteFormDialog for IT admins to enter deletion reason
- send reason to server and include it in email notification
- document new admin deletion behavior
- send deletion email to form owner when any form is deleted
- add IIS hosting instructions to README

## Testing
- `dotnet build DynamicFormsApp.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68821654de6c8329a4c43acc433ed002