### PR TITLE
Fix section drag init

### DIFF
--- a/Client/Components/FieldEditor.razor
+++ b/Client/Components/FieldEditor.razor
@@ -8,6 +8,7 @@
             <div class="d-flex align-items-center gap-2">
                 <span class="drag-handle text-muted"><span class="material-icons fs-4">drag_indicator</span></span>
                 <input class="form-control form-control-sm" placeholder="Field label" @bind="Field.Label" />
+                <span class="badge bg-secondary">@GetTypeLabel(Field.FieldType)</span>
             </div>
             <div class="d-flex gap-2">
                 <button class="btn btn-sm btn-outline-secondary" @onclick="() => OnDuplicate.InvokeAsync(Field)">
@@ -21,7 +22,7 @@
 
         <div class="row g-2">
             <div class="col-md-4">
-                <select class="form-select" @bind="Field.FieldType">
+                <select class="form-select" @bind="Field.FieldType" @bind:after="OnTypeChanged">
                     <option value="text">Short Answer</option>
                     <option value="textarea">Paragraph</option>
                     <option value="radio">Multiple Choice</option>
@@ -38,6 +39,12 @@
                     <option value="file">Upload File</option>
                 </select>
             </div>
+            @if (Field.FieldType is "text" or "textarea")
+            {
+                <div class="col-md-8">
+                    <input class="form-control" placeholder="Placeholder" @bind="Field.Placeholder" />
+                </div>
+            }
         </div>
 
         @if (Field.FieldType is "radio" or "checkbox" or "dropdown")
@@ -116,4 +123,41 @@
     [Parameter] public EventCallback<DesignerField> OnDuplicate { get; set; }
     [Parameter(CaptureUnmatchedValues = true)]
     public Dictionary<string, object> AdditionalAttributes { get; set; } = new();
+
+    string GetTypeLabel(string type) => type switch
+    {
+        "text" => "Short Answer",
+        "textarea" => "Paragraph",
+        "radio" => "Multiple Choice",
+        "checkbox" => "Checkbox",
+        "dropdown" => "Dropdown",
+        "date" => "Date",
+        "time" => "Time",
+        "datetime" => "Date Time",
+        "scale" => "Linear Scale",
+        "grid_radio" => "Choice Grid",
+        "grid_checkbox" => "Checkbox Grid",
+        "title" => "Title",
+        "section" => "Section",
+        "file" => "Upload File",
+        _ => type
+    };
+
+    void OnTypeChanged()
+    {
+        if (Field.FieldType == "text")
+        {
+            if (string.IsNullOrWhiteSpace(Field.Placeholder))
+                Field.Placeholder = "Short answer";
+        }
+        else if (Field.FieldType == "textarea")
+        {
+            if (string.IsNullOrWhiteSpace(Field.Placeholder))
+                Field.Placeholder = "Paragraph";
+        }
+        else
+        {
+            Field.Placeholder = string.Empty;
+        }
+    }
 }

--- a/Client/Components/FieldEditor.razor
+++ b/Client/Components/FieldEditor.razor
@@ -20,32 +20,14 @@
             </div>
         </div>
 
-        <div class="row g-2">
-            <div class="col-md-4">
-                <select class="form-select" @bind="Field.FieldType" @bind:after="OnTypeChanged">
-                    <option value="text">Short Answer</option>
-                    <option value="textarea">Paragraph</option>
-                    <option value="radio">Multiple Choice</option>
-                    <option value="checkbox">Checkbox</option>
-                    <option value="dropdown">Dropdown</option>
-                    <option value="date">Date</option>
-                    <option value="time">Time</option>
-                    <option value="datetime">Date Time</option>
-                    <option value="scale">Linear Scale</option>
-                    <option value="grid_radio">Multiple Choice Grid</option>
-                    <option value="grid_checkbox">Checkbox Grid</option>
-                    <option value="title">Title</option>
-                    <option value="section">Section</option>
-                    <option value="file">Upload File</option>
-                </select>
+        @if (Field.FieldType is "text" or "textarea")
+        {
+            <div class="mb-3">
+                <label class="form-label">Placeholder Text</label>
+                <input class="form-control" @bind="Field.Placeholder" placeholder="e.g., Enter your answer" />
+                <div class="form-text">Shown inside the field until the user enters a value.</div>
             </div>
-            @if (Field.FieldType is "text" or "textarea")
-            {
-                <div class="col-md-8">
-                    <input class="form-control" placeholder="Placeholder" @bind="Field.Placeholder" />
-                </div>
-            }
-        </div>
+        }
 
         @if (Field.FieldType is "radio" or "checkbox" or "dropdown")
         {
@@ -143,21 +125,4 @@
         _ => type
     };
 
-    void OnTypeChanged()
-    {
-        if (Field.FieldType == "text")
-        {
-            if (string.IsNullOrWhiteSpace(Field.Placeholder))
-                Field.Placeholder = "Short answer";
-        }
-        else if (Field.FieldType == "textarea")
-        {
-            if (string.IsNullOrWhiteSpace(Field.Placeholder))
-                Field.Placeholder = "Paragraph";
-        }
-        else
-        {
-            Field.Placeholder = string.Empty;
-        }
-    }
 }

--- a/Client/Components/LivePreview.razor
+++ b/Client/Components/LivePreview.razor
@@ -31,10 +31,10 @@
                     @switch (field.FieldType)
                     {
                         case "text":
-                            <input class="form-control" placeholder="Short answer" disabled />
+                            <input class="form-control" placeholder="@(!string.IsNullOrWhiteSpace(field.Placeholder) ? field.Placeholder : "Short answer")" disabled />
                             break;
                         case "textarea":
-                            <textarea class="form-control" placeholder="Paragraph" disabled></textarea>
+                            <textarea class="form-control" placeholder="@(!string.IsNullOrWhiteSpace(field.Placeholder) ? field.Placeholder : "Paragraph")" disabled></textarea>
                             break;
                         case "radio":
                             @foreach (var opt in field.OptionItems)

--- a/Client/Components/LivePreview.razor
+++ b/Client/Components/LivePreview.razor
@@ -1,4 +1,4 @@
-﻿@using DynamicFormsApp.Shared
+@using DynamicFormsApp.Shared
 
 <h5 class="text-muted">Live Preview</h5>
 @if (!string.IsNullOrWhiteSpace(FormName))
@@ -6,128 +6,126 @@
     <h3 class="mb-3">@FormName</h3>
 }
 
-@foreach (var row in Rows)
+@foreach (var section in Sections)
 {
-    <div class="row g-3 mb-3">
-    @foreach (var field in row.Fields)
-    {
-        <div class="col-12 col-md-@(12 / (row.Fields.Count == 0 ? 1 : row.Fields.Count)) mb-3">
-            @if (field.FieldType != "title" && field.FieldType != "section")
-            {
-                <label class="form-label">@field.Label</label>
-            }
-
-        @switch (field.FieldType)
+    <div class="mb-4">
+        <hr />
+        @if (!string.IsNullOrWhiteSpace(section.Title))
         {
-            case "text":
-                <input class="form-control" placeholder="Short answer" disabled />
-                break;
-
-            case "textarea":
-                <textarea class="form-control" placeholder="Paragraph" disabled></textarea>
-                break;
-
-            case "radio":
-                @foreach (var opt in field.OptionItems)
-                {
-                    <div class="form-check">
-                        <input class="form-check-input" type="radio" disabled />
-                        <label class="form-check-label">@opt</label>
-                    </div>
-                }
-                break;
-
-            case "checkbox":
-                @foreach (var opt in field.OptionItems)
-                {
-                    <div class="form-check">
-                        <input class="form-check-input" type="checkbox" disabled />
-                        <label class="form-check-label">@opt</label>
-                    </div>
-                }
-                break;
-
-            case "dropdown":
-                <select class="form-select" disabled>
-                    @foreach (var opt in field.OptionItems)
+            <h5>@(section.Title)</h5>
+        }
+        @if (!string.IsNullOrWhiteSpace(section.Instructions))
+        {
+            <p class="text-muted">@(section.Instructions)</p>
+        }
+        @foreach (var row in section.Rows)
+        {
+            <div class="row g-3 mb-3">
+            @foreach (var field in row.Fields)
+            {
+                <div class="col-12 col-md-@(12 / (row.Fields.Count == 0 ? 1 : row.Fields.Count)) mb-3">
+                    @if (field.FieldType != "title" && field.FieldType != "section")
                     {
-                        <option>@opt</option>
+                        <label class="form-label">@field.Label</label>
                     }
-                </select>
-                break;
-
-            case "scale":
-                <div class="d-flex align-items-center gap-3">
-                    @for (int i = field.ScaleMin; i <= field.ScaleMax; i++)
+                    @switch (field.FieldType)
                     {
-                        <div class="form-check">
-                            <input type="radio" disabled class="form-check-input" />
-                            <label class="form-check-label">@i</label>
-                        </div>
+                        case "text":
+                            <input class="form-control" placeholder="Short answer" disabled />
+                            break;
+                        case "textarea":
+                            <textarea class="form-control" placeholder="Paragraph" disabled></textarea>
+                            break;
+                        case "radio":
+                            @foreach (var opt in field.OptionItems)
+                            {
+                                <div class="form-check">
+                                    <input class="form-check-input" type="radio" disabled />
+                                    <label class="form-check-label">@opt</label>
+                                </div>
+                            }
+                            break;
+                        case "checkbox":
+                            @foreach (var opt in field.OptionItems)
+                            {
+                                <div class="form-check">
+                                    <input class="form-check-input" type="checkbox" disabled />
+                                    <label class="form-check-label">@opt</label>
+                                </div>
+                            }
+                            break;
+                        case "dropdown":
+                            <select class="form-select" disabled>
+                                @foreach (var opt in field.OptionItems)
+                                {
+                                    <option>@opt</option>
+                                }
+                            </select>
+                            break;
+                        case "scale":
+                            <div class="d-flex align-items-center gap-3">
+                                @for (int i = field.ScaleMin; i <= field.ScaleMax; i++)
+                                {
+                                    <div class="form-check">
+                                        <input type="radio" disabled class="form-check-input" />
+                                        <label class="form-check-label">@i</label>
+                                    </div>
+                                }
+                            </div>
+                            break;
+                        case "grid_radio":
+                        case "grid_checkbox":
+                            <table class="table table-bordered table-sm">
+                                <thead>
+                                    <tr>
+                                        <th></th>
+                                        @foreach (var col in field.GridColumns)
+                                        {
+                                            <th>@col</th>
+                                        }
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @foreach (var gridRow in field.GridRows)
+                                    {
+                                        <tr>
+                                            <td><strong>@gridRow</strong></td>
+                                            @foreach (var col in field.GridColumns)
+                                            {
+                                                <td>
+                                                    @if (field.FieldType == "grid_radio")
+                                                    {
+                                                        <input type="radio" disabled />
+                                                    }
+                                                    else
+                                                    {
+                                                        <input type="checkbox" disabled />
+                                                    }
+                                                </td>
+                                            }
+                                        </tr>
+                                    }
+                                </tbody>
+                            </table>
+                            break;
+                        case "file":
+                            <input type="file" class="form-control" disabled />
+                            break;
+                        case "title":
+                            <h4 class="text-muted">@field.Label</h4>
+                            break;
+                        default:
+                            <input class="form-control" disabled />
+                            break;
                     }
                 </div>
-                break;
-
-            case "grid_radio":
-            case "grid_checkbox":
-                <table class="table table-bordered table-sm">
-                    <thead>
-                        <tr>
-                            <th></th>
-                            @foreach (var col in field.GridColumns)
-                            {
-                                <th>@col</th>
-                            }
-                        </tr>
-                    </thead>
-                    <tbody>
-                        @foreach (var gridRow in field.GridRows)
-                        {
-                            <tr>
-                                <td><strong>@gridRow</strong></td>
-                                @foreach (var col in field.GridColumns)
-                                {
-                                    <td>
-                                        @if (field.FieldType == "grid_radio")
-                                        {
-                                            <input type="radio" disabled />
-                                        }
-                                        else
-                                        {
-                                            <input type="checkbox" disabled />
-                                        }
-                                    </td>
-                                }
-                            </tr>
-                        }
-                    </tbody>
-                </table>
-                break;
-
-            case "file":
-                <input type="file" class="form-control" disabled />
-                break;
-
-            case "title":
-                <h4 class="text-muted">@field.Label</h4>
-                break;
-
-            case "section":
-                <hr />
-                <h5>@field.Label</h5>
-                break;
-
-            default:
-                <input class="form-control" disabled />
-                break;
+            }
+            </div>
         }
-
-        </div>
-    }
     </div>
 }
 
 @code {
-    [Parameter] public List<DesignerRow> Rows { get; set; } = new();
+    [Parameter] public List<DesignerSection> Sections { get; set; } = new();
     [Parameter] public string? FormName { get; set; }
 }

--- a/Client/Pages/DynamicForms/EditFormPage.razor
+++ b/Client/Pages/DynamicForms/EditFormPage.razor
@@ -24,7 +24,7 @@ else if (!string.IsNullOrEmpty(deletedMessage))
 }
 <p class="text-muted">Drag fields to reorder or move them between rows. Each row can have up to four columns.</p>
 
-<div class="form-check form-switch mb-4">
+<div class="form-check form-switch position-fixed top-0 end-0 m-3" style="z-index:1050;">
     <input class="form-check-input" type="checkbox" id="previewToggle" @bind="isPreviewMode" />
     <label class="form-check-label" for="previewToggle">Preview Mode</label>
 </div>

--- a/Client/Pages/DynamicForms/EditFormPage.razor
+++ b/Client/Pages/DynamicForms/EditFormPage.razor
@@ -277,6 +277,13 @@ async Task AddRow(int section)
         await JS.InvokeVoidAsync("initSortable", $"#section-{section}-rows", objRef!);
     }
 
+    DesignerField CreateField(string fieldType) => new DesignerField
+    {
+        FieldType = fieldType,
+        Placeholder = fieldType == "text" ? "Short answer" :
+                      fieldType == "textarea" ? "Paragraph" : string.Empty
+    };
+
     async Task AddField(int section, int row, string fieldType = "text")
     {
         if (sections[section].Rows[row].Fields.Count >= 4)
@@ -289,7 +296,7 @@ async Task AddRow(int section)
             });
             return;
         }
-        sections[section].Rows[row].Fields.Add(new DesignerField { FieldType = fieldType });
+        sections[section].Rows[row].Fields.Add(CreateField(fieldType));
         await JS.InvokeVoidAsync("initSortable", $"#section-{section}-rows", objRef!);
     }
 
@@ -321,6 +328,7 @@ async Task AddRow(int section)
             Key = string.Empty,
             Label = field.Label,
             FieldType = field.FieldType,
+            Placeholder = field.Placeholder,
             IsRequired = field.IsRequired,
             OptionItems = new List<string>(field.OptionItems),
             GridColumns = new List<string>(field.GridColumns),
@@ -353,7 +361,7 @@ public async Task AddFieldFromDrop(string fieldType, int sectionIndex, int rowIn
         rowIndex = sections[sectionIndex].Rows.Count - 1;
 
     var list = sections[sectionIndex].Rows[rowIndex].Fields;
-    var field = new DesignerField { FieldType = fieldType };
+    var field = CreateField(fieldType);
 
         if (list.Count >= 4)
         {
@@ -392,7 +400,7 @@ public async Task AddRowFromDrop(string fieldType, int sectionIndex, int insertI
         insertIndex = sections[sectionIndex].Rows.Count;
 
     var row = new DesignerRow();
-    row.Fields.Add(new DesignerField { FieldType = fieldType });
+    row.Fields.Add(CreateField(fieldType));
     sections[sectionIndex].Rows.Insert(insertIndex, row);
     StateHasChanged();
     await JS.InvokeVoidAsync("initSortable", $"#section-{sectionIndex}-rows", objRef!);
@@ -456,6 +464,7 @@ List<object> BuildFieldPayload()
                     f.Key,
                     f.Label,
                     f.FieldType,
+                    f.Placeholder,
                     f.IsRequired,
                     Row = rowCounter,
                     Column = c,
@@ -521,6 +530,7 @@ List<object> BuildFieldPayload()
                     Key = f.Key,
                     Label = f.Label,
                     FieldType = f.FieldType,
+                    Placeholder = f.Placeholder ?? string.Empty,
                     IsRequired = f.IsRequired
                 };
                 if (!string.IsNullOrWhiteSpace(f.OptionsJson))

--- a/Client/Pages/DynamicForms/EditFormPage.razor
+++ b/Client/Pages/DynamicForms/EditFormPage.razor
@@ -77,28 +77,59 @@ else if (!string.IsNullOrEmpty(deletedMessage))
             </div>
         </div>
         <div class="col-md-9">
-            <div id="fields-container">
-                @for (int r = 0; r < rows.Count; r++)
+            <div id="sections-container">
+                @for (int s = 0; s < sections.Count; s++)
                 {
-                    var rowIndex = r;
-                    <div class="row-dropzone" data-insert="@rowIndex"></div>
-                    <div class="row g-3 mb-3 designer-row" data-row="@rowIndex" @key="rows[rowIndex]">
-                        @for (int i = 0; i < rows[rowIndex].Fields.Count; i++)
-                        {
-                            <div class="col-12 col-md-@(12 / (rows[rowIndex].Fields.Count == 0 ? 1 : rows[rowIndex].Fields.Count))" data-id="@i" @key="rows[rowIndex].Fields[i]">
-                                <FieldEditor Field="rows[rowIndex].Fields[i]"
-                                             OnRemove="async f => await RemoveField(rowIndex, f)"
-                                             OnDuplicate="async f => await DuplicateField(rowIndex, f)" />
+                    var secIndex = s;
+                    <div class="section-wrapper mb-4" data-section="@secIndex" id="section-@secIndex" @key="sections[secIndex]">
+                        <div class="card">
+                            <div class="card-header d-flex justify-content-between align-items-center">
+                                <div class="d-flex align-items-center gap-2">
+                                    <span class="material-icons section-drag-handle">drag_indicator</span>
+                                    <input class="form-control form-control-sm" placeholder="Section title" @bind="sections[secIndex].Title" />
+                                </div>
+                                <div class="d-flex gap-2">
+                                    <button class="btn btn-sm btn-outline-secondary" @onclick="() => ToggleCollapse(secIndex)">
+                                        <span class="material-icons">@(!sections[secIndex].IsCollapsed ? "expand_less" : "expand_more")</span>
+                                    </button>
+                                    <button class="btn btn-sm btn-outline-danger" @onclick="() => DeleteSection(secIndex)">
+                                        <span class="material-icons">delete</span>
+                                    </button>
+                                </div>
                             </div>
-                        }
-                        <div class="col-12 no-drop">
-                            <button class="btn btn-sm btn-primary" @onclick="() => AddField(rowIndex)">+ Add Column</button>
+                            <div class="card-body" hidden="@sections[secIndex].IsCollapsed">
+                                <textarea class="form-control mb-3" placeholder="Section instructions" @bind="sections[secIndex].Instructions"></textarea>
+                                <div id="section-@secIndex-rows">
+                                    @for (int r = 0; r < sections[secIndex].Rows.Count; r++)
+                                    {
+                                        var rowIndex = r;
+                                        <div class="row-dropzone" data-section="@secIndex" data-insert="@rowIndex"></div>
+                                        <div class="row g-3 mb-3 designer-row" data-section="@secIndex" data-row="@rowIndex" @key="sections[secIndex].Rows[rowIndex]">
+                                            @for (int i = 0; i < sections[secIndex].Rows[rowIndex].Fields.Count; i++)
+                                            {
+                                                <div class="col-12 col-md-@(12 / (sections[secIndex].Rows[rowIndex].Fields.Count == 0 ? 1 : sections[secIndex].Rows[rowIndex].Fields.Count))" data-id="@i" @key="sections[secIndex].Rows[rowIndex].Fields[i]">
+                                                    <FieldEditor Field="sections[secIndex].Rows[rowIndex].Fields[i]"
+                                                                 OnRemove="async f => await RemoveField(secIndex, rowIndex, f)"
+                                                                 OnDuplicate="async f => await DuplicateField(secIndex, rowIndex, f)" />
+                                                </div>
+                                            }
+                                            <div class="col-12 no-drop">
+                                                <button class="btn btn-sm btn-primary" @onclick="() => AddField(secIndex, rowIndex)">+ Add Column</button>
+                                            </div>
+                                        </div>
+                                    }
+                                    <div class="row-dropzone" data-section="@secIndex" data-insert="@sections[secIndex].Rows.Count"></div>
+                                    <div class="d-grid mb-3">
+                                        <button class="btn btn-primary" @onclick="() => AddRow(secIndex)">+ Add Row</button>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
                     </div>
                 }
-                <div class="row-dropzone" data-insert="@rows.Count"></div>
+                <div class="section-dropzone" data-insert="@sections.Count"></div>
                 <div class="d-grid mb-3">
-                    <button class="btn btn-primary" @onclick="AddRow">+ Add Row</button>
+                    <button class="btn btn-secondary" @onclick="AddSection">+ Add Section</button>
                 </div>
                 @if (isDraft)
                 {
@@ -122,7 +153,7 @@ else if (!string.IsNullOrEmpty(deletedMessage))
 else
 {
     <div class="card p-3 shadow-sm">
-        <LivePreview Rows="rows" FormName="@formName" />
+        <LivePreview Sections="sections" FormName="@formName" />
     </div>
 }
 
@@ -130,7 +161,7 @@ else
     [Parameter] public int FormId { get; set; }
     private string formName = string.Empty;
     private string formDescription = string.Empty;
-    private List<DesignerRow> rows = new() { new DesignerRow() };
+    private List<DesignerSection> sections = new() { new DesignerSection() };
     private bool isPreviewMode = false;
     private bool requireLogin = true;
     private bool notifyOnResponse = false;
@@ -178,7 +209,7 @@ else
             notifyOnResponse = form.NotifyOnResponse;
             notificationEmail = form.NotificationEmail ?? notificationEmail;
             isDraft = form.IsDraft;
-            rows = BuildDesignerRows(form);
+            sections = BuildDesignerSections(form);
 
             objRef ??= DotNetObjectReference.Create(this);
             StateHasChanged();
@@ -187,57 +218,68 @@ else
         if (!isPreviewMode)
         {
             objRef ??= DotNetObjectReference.Create(this);
-            await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef);
-            await JS.InvokeVoidAsync("initFieldDragDrop", "#fields-container", objRef);
+            await JS.InvokeVoidAsync("initSectionSortable", "#sections-container", objRef);
+            for (int i = 0; i < sections.Count; i++)
+            {
+                await JS.InvokeVoidAsync("initSortable", $"#section-{i}-rows", objRef);
+            }
+            await JS.InvokeVoidAsync("initFieldDragDrop", "#sections-container", objRef);
         }
     }
 
-    [JSInvokable]
-    public void OnSortUpdate(int fromRow, int oldIndex, int toRow, int newIndex)
+[JSInvokable]
+public void OnSortUpdate(int fromSection, int fromRow, int oldIndex, int toSection, int toRow, int newIndex)
+{
+    if (fromSection < 0 || fromSection >= sections.Count || toSection < 0 || toSection >= sections.Count)
+        return;
+
+    if (fromRow < 0 || fromRow >= sections[fromSection].Rows.Count || toRow < 0 || toRow >= sections[toSection].Rows.Count)
+        return;
+
+    var source = sections[fromSection].Rows[fromRow].Fields;
+    var dest = sections[toSection].Rows[toRow].Fields;
+
+    if (oldIndex < 0 || oldIndex >= source.Count || newIndex < 0 || newIndex > dest.Count)
+        return;
+
+    if (fromRow != toRow && dest.Count >= 4)
     {
-        if (fromRow < 0 || fromRow >= rows.Count || toRow < 0 || toRow >= rows.Count)
-            return;
-
-        var source = rows[fromRow].Fields;
-        var dest = rows[toRow].Fields;
-
-        if (oldIndex < 0 || oldIndex >= source.Count || newIndex < 0 || newIndex > dest.Count)
-            return;
-
-        if (fromRow != toRow && dest.Count >= 4)
+        NotificationService.Notify(new NotificationMessage
         {
-            NotificationService.Notify(new NotificationMessage
-            {
-                Severity = NotificationSeverity.Warning,
-                Summary = "Column limit reached",
-                Detail = "A row can contain at most four columns."
-            });
-            StateHasChanged();
-            return;
-        }
-
-        var moved = source[oldIndex];
-        source.RemoveAt(oldIndex);
-
-        int insertIndex = Math.Min(newIndex, dest.Count);
-        dest.Insert(insertIndex, moved);
-        if (source.Count == 0 && rows.Count > 1)
-        {
-            rows.RemoveAt(fromRow);
-        }
+            Severity = NotificationSeverity.Warning,
+            Summary = "Column limit reached",
+            Detail = "A row can contain at most four columns."
+        });
         StateHasChanged();
-        JS.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
+        return;
     }
 
-    async Task AddRow()
+    var moved = source[oldIndex];
+    source.RemoveAt(oldIndex);
+
+    int insertIndex = Math.Min(newIndex, dest.Count);
+    dest.Insert(insertIndex, moved);
+    if (source.Count == 0 && sections[fromSection].Rows.Count > 1)
     {
-        rows.Add(new DesignerRow());
-        await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
+        sections[fromSection].Rows.RemoveAt(fromRow);
+    }
+    StateHasChanged();
+    JS.InvokeVoidAsync("initSortable", $"#section-{fromSection}-rows", objRef!);
+    if (fromSection != toSection)
+    {
+        JS.InvokeVoidAsync("initSortable", $"#section-{toSection}-rows", objRef!);
+    }
+}
+
+async Task AddRow(int section)
+{
+        sections[section].Rows.Add(new DesignerRow());
+        await JS.InvokeVoidAsync("initSortable", $"#section-{section}-rows", objRef!);
     }
 
-    async Task AddField(int row)
+    async Task AddField(int section, int row, string fieldType = "text")
     {
-        if (rows[row].Fields.Count >= 4)
+        if (sections[section].Rows[row].Fields.Count >= 4)
         {
             NotificationService.Notify(new NotificationMessage
             {
@@ -247,11 +289,11 @@ else
             });
             return;
         }
-        rows[row].Fields.Add(new DesignerField());
-        await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
+        sections[section].Rows[row].Fields.Add(new DesignerField { FieldType = fieldType });
+        await JS.InvokeVoidAsync("initSortable", $"#section-{section}-rows", objRef!);
     }
 
-    async Task RemoveField(int row, DesignerField field)
+    async Task RemoveField(int section, int row, DesignerField field)
     {
         if (!isDraft)
         {
@@ -264,15 +306,15 @@ else
                 return;
         }
 
-        rows[row].Fields.Remove(field);
-        if (rows[row].Fields.Count == 0 && rows.Count > 1)
+        sections[section].Rows[row].Fields.Remove(field);
+        if (sections[section].Rows[row].Fields.Count == 0 && sections[section].Rows.Count > 1)
         {
-            rows.RemoveAt(row);
+            sections[section].Rows.RemoveAt(row);
         }
-        await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
+        await JS.InvokeVoidAsync("initSortable", $"#section-{section}-rows", objRef!);
     }
 
-    async Task DuplicateField(int row, DesignerField field)
+    async Task DuplicateField(int section, int row, DesignerField field)
     {
         var copy = new DesignerField
         {
@@ -286,7 +328,7 @@ else
             ScaleMin = field.ScaleMin,
             ScaleMax = field.ScaleMax
         };
-        var list = rows[row].Fields;
+        var list = sections[section].Rows[row].Fields;
         if (list.Count >= 4)
         {
             NotificationService.Notify(new NotificationMessage
@@ -299,17 +341,19 @@ else
         }
 
         list.Insert(list.IndexOf(field) + 1, copy);
-        await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
+        await JS.InvokeVoidAsync("initSortable", $"#section-{section}-rows", objRef!);
     }
 
-    [JSInvokable]
-    public async Task AddFieldFromDrop(string fieldType, int rowIndex, int colIndex)
-    {
-        if (rowIndex < 0 || rowIndex >= rows.Count)
-            rowIndex = rows.Count - 1;
+[JSInvokable]
+public async Task AddFieldFromDrop(string fieldType, int sectionIndex, int rowIndex, int colIndex)
+{
+    if (sectionIndex < 0 || sectionIndex >= sections.Count)
+        sectionIndex = sections.Count - 1;
+    if (rowIndex < 0 || rowIndex >= sections[sectionIndex].Rows.Count)
+        rowIndex = sections[sectionIndex].Rows.Count - 1;
 
-        var list = rows[rowIndex].Fields;
-        var field = new DesignerField { FieldType = fieldType };
+    var list = sections[sectionIndex].Rows[rowIndex].Fields;
+    var field = new DesignerField { FieldType = fieldType };
 
         if (list.Count >= 4)
         {
@@ -323,40 +367,154 @@ else
             return;
         }
 
-        if (colIndex < 0 || colIndex > list.Count)
-            list.Add(field);
-        else
-            list.Insert(colIndex, field);
+    if (colIndex < 0 || colIndex > list.Count)
+        list.Add(field);
+    else
+        list.Insert(colIndex, field);
 
-        StateHasChanged();
-        await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
-    }
+    StateHasChanged();
+    await JS.InvokeVoidAsync("initSortable", $"#section-{sectionIndex}-rows", objRef!);
+}
 
-    [JSInvokable]
-    public async Task AddRowFromDrop(string fieldType, int insertIndex)
+async Task AddSection()
+{
+    sections.Add(new DesignerSection());
+    await JS.InvokeVoidAsync("initSectionSortable", "#sections-container", objRef!);
+    await JS.InvokeVoidAsync("initSortable", $"#section-{sections.Count - 1}-rows", objRef!);
+}
+
+[JSInvokable]
+public async Task AddRowFromDrop(string fieldType, int sectionIndex, int insertIndex)
+{
+    if (sectionIndex < 0 || sectionIndex >= sections.Count)
+        sectionIndex = sections.Count - 1;
+    if (insertIndex < 0 || insertIndex > sections[sectionIndex].Rows.Count)
+        insertIndex = sections[sectionIndex].Rows.Count;
+
+    var row = new DesignerRow();
+    row.Fields.Add(new DesignerField { FieldType = fieldType });
+    sections[sectionIndex].Rows.Insert(insertIndex, row);
+    StateHasChanged();
+    await JS.InvokeVoidAsync("initSortable", $"#section-{sectionIndex}-rows", objRef!);
+}
+
+[JSInvokable]
+public void OnSectionReorder(int oldIndex, int newIndex)
+{
+    if (oldIndex == newIndex || oldIndex < 0 || newIndex < 0 || oldIndex >= sections.Count || newIndex >= sections.Count)
+        return;
+    var item = sections[oldIndex];
+    sections.RemoveAt(oldIndex);
+    sections.Insert(newIndex, item);
+    StateHasChanged();
+}
+
+void ToggleCollapse(int index)
+{
+    sections[index].IsCollapsed = !sections[index].IsCollapsed;
+}
+
+async Task DeleteSection(int index)
+{
+    bool? confirm = await DialogService.Confirm(
+        "Delete this section and all its fields?",
+        "Delete Section",
+        new ConfirmOptions { OkButtonText = "Yes", CancelButtonText = "No" });
+    if (confirm == true)
     {
-        if (insertIndex < 0 || insertIndex > rows.Count)
-            insertIndex = rows.Count;
-
-        var row = new DesignerRow();
-        row.Fields.Add(new DesignerField { FieldType = fieldType });
-        rows.Insert(insertIndex, row);
-        StateHasChanged();
-        await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
+        sections.RemoveAt(index);
+        await JS.InvokeVoidAsync("initSectionSortable", "#sections-container", objRef!);
     }
+}
 
-    private List<DesignerRow> BuildDesignerRows(Form form)
+List<object> BuildFieldPayload()
+{
+    var list = new List<object>();
+    int rowCounter = 0;
+    foreach (var sec in sections)
     {
-        var result = new List<DesignerRow>();
-        var groups = form.Fields
-            .OrderBy(f => f.Row ?? 0)
-            .ThenBy(f => f.Column ?? 0)
-            .GroupBy(f => f.Row ?? 0);
-
-        foreach (var g in groups)
+        list.Add(new
         {
+            Key = sec.Key,
+            Label = sec.Title,
+            FieldType = "section",
+            IsRequired = false,
+            Row = rowCounter,
+            Column = 0,
+            OptionsJson = string.IsNullOrWhiteSpace(sec.Instructions) ? null :
+                JsonSerializer.Serialize(new { Instructions = sec.Instructions })
+        });
+        rowCounter++;
+
+        foreach (var row in sec.Rows)
+        {
+            for (int c = 0; c < row.Fields.Count; c++)
+            {
+                var f = row.Fields[c];
+                list.Add(new
+                {
+                    f.Key,
+                    f.Label,
+                    f.FieldType,
+                    f.IsRequired,
+                    Row = rowCounter,
+                    Column = c,
+                    OptionsJson = JsonSerializer.Serialize(
+                        f.OptionItems.Count > 0 ? f.OptionItems :
+                        f.GridRows.Count > 0 || f.GridColumns.Count > 0 ? new { Rows = f.GridRows, Columns = f.GridColumns } :
+                        f.FieldType == "scale" ? new { Min = f.ScaleMin, Max = f.ScaleMax } :
+                        !string.IsNullOrWhiteSpace(f.Instructions) ? new { Instructions = f.Instructions } :
+                        new object()
+                    )
+                });
+            }
+            rowCounter++;
+        }
+    }
+    return list;
+}
+
+    private List<DesignerSection> BuildDesignerSections(Form form)
+    {
+        var result = new List<DesignerSection>();
+        var ordered = form.Fields.OrderBy(f => f.Row ?? 0).ThenBy(f => f.Column ?? 0).ToList();
+
+        DesignerSection? current = null;
+        foreach (var group in ordered.GroupBy(f => f.Row ?? 0).OrderBy(g => g.Key))
+        {
+            var fields = group.OrderBy(f => f.Column ?? 0).ToList();
+            if (fields.Count == 1 && fields[0].FieldType == "section")
+            {
+                var secField = fields[0];
+                string instr = string.Empty;
+                if (!string.IsNullOrWhiteSpace(secField.OptionsJson))
+                {
+                    try
+                    {
+                        using var doc = JsonDocument.Parse(secField.OptionsJson);
+                        if (doc.RootElement.TryGetProperty("Instructions", out var instEl))
+                            instr = instEl.GetString() ?? string.Empty;
+                    }
+                    catch { }
+                }
+                current = new DesignerSection
+                {
+                    Key = secField.Key,
+                    Title = secField.Label,
+                    Instructions = instr
+                };
+                result.Add(current);
+                continue;
+            }
+
+            if (current == null)
+            {
+                current = new DesignerSection();
+                result.Add(current);
+            }
+
             var row = new DesignerRow();
-            foreach (var f in g)
+            foreach (var f in fields)
             {
                 var field = new DesignerField
                 {
@@ -375,12 +533,12 @@ else
                 }
                 row.Fields.Add(field);
             }
-            result.Add(row);
+            current.Rows.Add(row);
         }
 
         if (result.Count == 0)
         {
-            result.Add(new DesignerRow());
+            result.Add(new DesignerSection());
         }
         return result;
     }
@@ -398,7 +556,7 @@ else
             return;
         }
 
-        foreach (var f in rows.SelectMany(r => r.Fields))
+        foreach (var f in sections.SelectMany(s => s.Rows).SelectMany(r => r.Fields))
         {
             if (string.IsNullOrWhiteSpace(f.Label))
             {
@@ -432,20 +590,7 @@ else
             NotificationEmail = string.IsNullOrWhiteSpace(notificationEmail) ? null : notificationEmail,
             IsActive = true,
             IsDraft = draft,
-            Fields = rows.SelectMany((row, rIdx) => row.Fields.Select((f, cIdx) => new
-            {
-                f.Key,
-                f.Label,
-                f.FieldType,
-                f.IsRequired,
-                Row = rIdx,
-                Column = cIdx,
-                OptionsJson = JsonSerializer.Serialize(
-                    f.OptionItems.Count > 0 ? f.OptionItems :
-                    f.GridRows.Count > 0 || f.GridColumns.Count > 0 ? new { Rows = f.GridRows, Columns = f.GridColumns } :
-                    f.FieldType == "scale" ? new { Min = f.ScaleMin, Max = f.ScaleMax } : new object()
-                )
-            })).ToList()
+            Fields = BuildFieldPayload()
         };
 
         var resp = await Http.PutAsJsonAsync($"api/forms/{FormId}", payload);

--- a/Client/Pages/DynamicForms/FormRenderer.razor
+++ b/Client/Pages/DynamicForms/FormRenderer.razor
@@ -137,7 +137,14 @@ else
 
                     case "section":
                         <hr />
-                        <h5>@fld.Label</h5>
+                        @if (!string.IsNullOrWhiteSpace(fld.Label))
+                        {
+                            <h5>@fld.Label</h5>
+                        }
+                        @if (!string.IsNullOrWhiteSpace(GetInstructions(fld)))
+                        {
+                            <p class="text-muted">@GetInstructions(fld)</p>
+                        }
                         break;
 
                     case "scale":
@@ -213,6 +220,11 @@ else
 
             foreach (var fld in form.Fields)
             {
+                if (fld.FieldType == "section" || fld.FieldType == "title")
+                {
+                    continue;
+                }
+
                 responseData[fld.Key] = fld.FieldType switch
                 {
                     "checkbox" => new List<string>(),
@@ -234,6 +246,20 @@ else
     string GetDateString(string key) => responseData[key] is DateTime dt ? dt.ToString("yyyy-MM-dd") : "";
     string GetTimeString(string key) => responseData[key] is TimeSpan ts ? ts.ToString(@"hh\:mm") : "";
     string GetDateTimeString(string key) => responseData[key] is DateTime dt ? dt.ToString("yyyy-MM-ddTHH:mm") : "";
+
+    string? GetInstructions(FormField field)
+    {
+        if (string.IsNullOrWhiteSpace(field.OptionsJson))
+            return null;
+        try
+        {
+            using var doc = JsonDocument.Parse(field.OptionsJson);
+            if (doc.RootElement.TryGetProperty("Instructions", out var instEl))
+                return instEl.GetString();
+        }
+        catch { }
+        return null;
+    }
 
     void OnTextChanged(string key, ChangeEventArgs e) =>
         responseData[key] = e.Value?.ToString() ?? "";
@@ -329,7 +355,15 @@ else
             }
         }
 
-        await Http.PostAsJsonAsync($"api/forms/{FormId}/responses", responseData);
+        var submitData = responseData
+            .Where(kv =>
+                form.Fields.Any(f =>
+                    f.Key.Equals(kv.Key, StringComparison.OrdinalIgnoreCase) &&
+                    f.FieldType != "section" &&
+                    f.FieldType != "title"))
+            .ToDictionary(k => k.Key, v => v.Value);
+
+        await Http.PostAsJsonAsync($"api/forms/{FormId}/responses", submitData);
 
         var user = await CookieHelper.LoginStatus();
         if (string.IsNullOrEmpty(user))

--- a/Client/Pages/DynamicForms/FormRenderer.razor
+++ b/Client/Pages/DynamicForms/FormRenderer.razor
@@ -54,12 +54,13 @@ else
                 {
                     case "text":
                         <input type="text" class="form-control"
+                               placeholder="@fld.Placeholder"
                                value="@GetString(fld.Key)"
                                @onchange="e => OnTextChanged(fld.Key, e)" />
                         break;
 
                     case "textarea":
-                        <textarea class="form-control"
+                        <textarea class="form-control" placeholder="@fld.Placeholder"
                                   @onchange="e => OnTextChanged(fld.Key, e)">@GetString(fld.Key)</textarea>
                         break;
 

--- a/Client/Pages/DynamicForms/FormResponses.razor
+++ b/Client/Pages/DynamicForms/FormResponses.razor
@@ -141,7 +141,9 @@
             }
             responses = await respData.Content.ReadFromJsonAsync<List<Dictionary<string, object>>>();
 
-            var fieldKeys = form.Fields.Select(f => f.Key);
+            var fieldKeys = form.Fields
+                .Where(f => f.FieldType != "section" && f.FieldType != "title")
+                .Select(f => f.Key);
             columns = new[] { "ResponseId", "CreatedAt" }
                 .Concat(fieldKeys)
                 .ToArray();

--- a/Client/Pages/DynamicForms/Index.razor
+++ b/Client/Pages/DynamicForms/Index.razor
@@ -17,7 +17,7 @@
 <h2 class="mb-2">Form Builder</h2>
 <p class="text-muted">Drag fields to reorder or move them between rows. Each row can have up to four columns.</p>
 
-<div class="form-check form-switch mb-4">
+<div class="form-check form-switch position-fixed top-0 end-0 m-3" style="z-index:1050;">
     <input class="form-check-input" type="checkbox" id="previewToggle" @bind="isPreviewMode" />
     <label class="form-check-label" for="previewToggle">Preview Mode</label>
 </div>

--- a/Client/Pages/DynamicForms/Index.razor
+++ b/Client/Pages/DynamicForms/Index.razor
@@ -70,28 +70,59 @@
             </div>
         </div>
         <div class="col-md-9">
-            <div id="fields-container">
-                @for (int r = 0; r < rows.Count; r++)
+            <div id="sections-container">
+                @for (int s = 0; s < sections.Count; s++)
                 {
-                    var rowIndex = r;
-                    <div class="row-dropzone" data-insert="@rowIndex"></div>
-                    <div class="row g-3 mb-3 designer-row" data-row="@rowIndex" @key="rows[rowIndex]">
-                        @for (int i = 0; i < rows[rowIndex].Fields.Count; i++)
-                        {
-                            <div class="col-12 col-md-@(12 / (rows[rowIndex].Fields.Count == 0 ? 1 : rows[rowIndex].Fields.Count))" data-id="@i" @key="rows[rowIndex].Fields[i]">
-                                <FieldEditor Field="rows[rowIndex].Fields[i]"
-                                             OnRemove="async f => await RemoveField(rowIndex, f)"
-                                             OnDuplicate="async f => await DuplicateField(rowIndex, f)" />
+                    var secIndex = s;
+                    <div class="section-wrapper mb-4" data-section="@secIndex" id="section-@secIndex" @key="sections[secIndex]">
+                        <div class="card">
+                            <div class="card-header d-flex justify-content-between align-items-center">
+                                <div class="d-flex align-items-center gap-2">
+                                    <span class="material-icons section-drag-handle">drag_indicator</span>
+                                    <input class="form-control form-control-sm" placeholder="Section title" @bind="sections[secIndex].Title" />
+                                </div>
+                                <div class="d-flex gap-2">
+                                    <button class="btn btn-sm btn-outline-secondary" @onclick="() => ToggleCollapse(secIndex)">
+                                        <span class="material-icons">@(!sections[secIndex].IsCollapsed ? "expand_less" : "expand_more")</span>
+                                    </button>
+                                    <button class="btn btn-sm btn-outline-danger" @onclick="() => DeleteSection(secIndex)">
+                                        <span class="material-icons">delete</span>
+                                    </button>
+                                </div>
                             </div>
-                        }
-                        <div class="col-12 no-drop">
-                            <button class="btn btn-sm btn-primary" @onclick="() => AddField(rowIndex)">+ Add Column</button>
+                            <div class="card-body" hidden="@sections[secIndex].IsCollapsed">
+                                <textarea class="form-control mb-3" placeholder="Section instructions" @bind="sections[secIndex].Instructions"></textarea>
+                                <div id="section-@secIndex-rows">
+                                    @for (int r = 0; r < sections[secIndex].Rows.Count; r++)
+                                    {
+                                        var rowIndex = r;
+                                        <div class="row-dropzone" data-section="@secIndex" data-insert="@rowIndex"></div>
+                                        <div class="row g-3 mb-3 designer-row" data-section="@secIndex" data-row="@rowIndex" @key="sections[secIndex].Rows[rowIndex]">
+                                            @for (int i = 0; i < sections[secIndex].Rows[rowIndex].Fields.Count; i++)
+                                            {
+                                                <div class="col-12 col-md-@(12 / (sections[secIndex].Rows[rowIndex].Fields.Count == 0 ? 1 : sections[secIndex].Rows[rowIndex].Fields.Count))" data-id="@i" @key="sections[secIndex].Rows[rowIndex].Fields[i]">
+                                                    <FieldEditor Field="sections[secIndex].Rows[rowIndex].Fields[i]"
+                                                                 OnRemove="async f => await RemoveField(secIndex, rowIndex, f)"
+                                                                 OnDuplicate="async f => await DuplicateField(secIndex, rowIndex, f)" />
+                                                </div>
+                                            }
+                                            <div class="col-12 no-drop">
+                                                <button class="btn btn-sm btn-primary" @onclick="() => AddField(secIndex, rowIndex)">+ Add Column</button>
+                                            </div>
+                                        </div>
+                                    }
+                                    <div class="row-dropzone" data-section="@secIndex" data-insert="@sections[secIndex].Rows.Count"></div>
+                                    <div class="d-grid mb-3">
+                                        <button class="btn btn-primary" @onclick="() => AddRow(secIndex)">+ Add Row</button>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
                     </div>
                 }
-                <div class="row-dropzone" data-insert="@rows.Count"></div>
+                <div class="section-dropzone" data-insert="@sections.Count"></div>
                 <div class="d-grid mb-3">
-                    <button class="btn btn-primary" @onclick="AddRow">+ Add Row</button>
+                    <button class="btn btn-secondary" @onclick="AddSection">+ Add Section</button>
                 </div>
                 <div class="d-grid mb-2">
                     <button class="btn btn-primary btn-lg" @onclick="HandleSubmit">Create Form</button>
@@ -106,14 +137,14 @@
 else
 {
     <div class="card p-3 shadow-sm">
-        <LivePreview Rows="rows" FormName="@formName" />
+        <LivePreview Sections="sections" FormName="@formName" />
     </div>
 }
 
 @code {
     private string formName = string.Empty;
     private string formDescription = string.Empty;
-    private List<DesignerRow> rows = new() { new DesignerRow() };
+    private List<DesignerSection> sections = new() { new DesignerSection() };
     private bool isPreviewMode = false;
     private bool requireLogin = true;
     private bool notifyOnResponse = false;
@@ -142,19 +173,26 @@ else
         if (!isPreviewMode)
         {
             objRef ??= DotNetObjectReference.Create(this);
-            await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef);
-            await JS.InvokeVoidAsync("initFieldDragDrop", "#fields-container", objRef);
+            await JS.InvokeVoidAsync("initSectionSortable", "#sections-container", objRef);
+            for (int i = 0; i < sections.Count; i++)
+            {
+                await JS.InvokeVoidAsync("initSortable", $"#section-{i}-rows", objRef);
+            }
+            await JS.InvokeVoidAsync("initFieldDragDrop", "#sections-container", objRef);
         }
     }
 
     [JSInvokable]
-    public void OnSortUpdate(int fromRow, int oldIndex, int toRow, int newIndex)
+    public void OnSortUpdate(int fromSection, int fromRow, int oldIndex, int toSection, int toRow, int newIndex)
     {
-        if (fromRow < 0 || fromRow >= rows.Count || toRow < 0 || toRow >= rows.Count)
+        if (fromSection < 0 || fromSection >= sections.Count || toSection < 0 || toSection >= sections.Count)
             return;
 
-        var source = rows[fromRow].Fields;
-        var dest = rows[toRow].Fields;
+        if (fromRow < 0 || fromRow >= sections[fromSection].Rows.Count || toRow < 0 || toRow >= sections[toSection].Rows.Count)
+            return;
+
+        var source = sections[fromSection].Rows[fromRow].Fields;
+        var dest = sections[toSection].Rows[toRow].Fields;
 
         if (oldIndex < 0 || oldIndex >= source.Count || newIndex < 0 || newIndex > dest.Count)
             return;
@@ -177,23 +215,34 @@ else
         // clamp insert index to avoid out of range errors when moving within the same row
         int insertIndex = Math.Min(newIndex, dest.Count);
         dest.Insert(insertIndex, moved);
-        if (source.Count == 0 && rows.Count > 1)
+        if (source.Count == 0 && sections[fromSection].Rows.Count > 1)
         {
-            rows.RemoveAt(fromRow);
+            sections[fromSection].Rows.RemoveAt(fromRow);
         }
         StateHasChanged();
-        JS.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
+        JS.InvokeVoidAsync("initSortable", $"#section-{fromSection}-rows", objRef!);
+        if (fromSection != toSection)
+        {
+            JS.InvokeVoidAsync("initSortable", $"#section-{toSection}-rows", objRef!);
+        }
     }
 
-    async Task AddRow()
+    async Task AddRow(int section)
     {
-        rows.Add(new DesignerRow());
-        await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
+        sections[section].Rows.Add(new DesignerRow());
+        await JS.InvokeVoidAsync("initSortable", $"#section-{section}-rows", objRef!);
     }
 
-    async Task AddField(int row)
+    async Task AddSection()
     {
-        if (rows[row].Fields.Count >= 4)
+        sections.Add(new DesignerSection());
+        await JS.InvokeVoidAsync("initSectionSortable", "#sections-container", objRef!);
+        await JS.InvokeVoidAsync("initSortable", $"#section-{sections.Count - 1}-rows", objRef!);
+    }
+
+    async Task AddField(int section, int row, string fieldType = "text")
+    {
+        if (sections[section].Rows[row].Fields.Count >= 4)
         {
             NotificationService.Notify(new NotificationMessage
             {
@@ -203,21 +252,21 @@ else
             });
             return;
         }
-        rows[row].Fields.Add(new DesignerField());
-        await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
+        sections[section].Rows[row].Fields.Add(new DesignerField { FieldType = fieldType });
+        await JS.InvokeVoidAsync("initSortable", $"#section-{section}-rows", objRef!);
     }
 
-    async Task RemoveField(int row, DesignerField field)
+    async Task RemoveField(int section, int row, DesignerField field)
     {
-        rows[row].Fields.Remove(field);
-        if (rows[row].Fields.Count == 0 && rows.Count > 1)
+        sections[section].Rows[row].Fields.Remove(field);
+        if (sections[section].Rows[row].Fields.Count == 0 && sections[section].Rows.Count > 1)
         {
-            rows.RemoveAt(row);
+            sections[section].Rows.RemoveAt(row);
         }
-        await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
+        await JS.InvokeVoidAsync("initSortable", $"#section-{section}-rows", objRef!);
     }
 
-    async Task DuplicateField(int row, DesignerField field)
+    async Task DuplicateField(int section, int row, DesignerField field)
     {
         var copy = new DesignerField
         {
@@ -231,7 +280,7 @@ else
             ScaleMin = field.ScaleMin,
             ScaleMax = field.ScaleMax
         };
-        var list = rows[row].Fields;
+        var list = sections[section].Rows[row].Fields;
         if (list.Count >= 4)
         {
             NotificationService.Notify(new NotificationMessage
@@ -244,16 +293,18 @@ else
         }
 
         list.Insert(list.IndexOf(field) + 1, copy);
-        await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
+        await JS.InvokeVoidAsync("initSortable", $"#section-{section}-rows", objRef!);
     }
 
     [JSInvokable]
-    public async Task AddFieldFromDrop(string fieldType, int rowIndex, int colIndex)
+    public async Task AddFieldFromDrop(string fieldType, int sectionIndex, int rowIndex, int colIndex)
     {
-        if (rowIndex < 0 || rowIndex >= rows.Count)
-            rowIndex = rows.Count - 1;
+        if (sectionIndex < 0 || sectionIndex >= sections.Count)
+            sectionIndex = sections.Count - 1;
+        if (rowIndex < 0 || rowIndex >= sections[sectionIndex].Rows.Count)
+            rowIndex = sections[sectionIndex].Rows.Count - 1;
 
-        var list = rows[rowIndex].Fields;
+        var list = sections[sectionIndex].Rows[rowIndex].Fields;
         var field = new DesignerField { FieldType = fieldType };
 
         if (list.Count >= 4)
@@ -274,20 +325,96 @@ else
             list.Insert(colIndex, field);
 
         StateHasChanged();
-        await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
+        await JS.InvokeVoidAsync("initSortable", $"#section-{sectionIndex}-rows", objRef!);
     }
 
     [JSInvokable]
-    public async Task AddRowFromDrop(string fieldType, int insertIndex)
+    public async Task AddRowFromDrop(string fieldType, int sectionIndex, int insertIndex)
     {
-        if (insertIndex < 0 || insertIndex > rows.Count)
-            insertIndex = rows.Count;
+        if (sectionIndex < 0 || sectionIndex >= sections.Count)
+            sectionIndex = sections.Count - 1;
+        if (insertIndex < 0 || insertIndex > sections[sectionIndex].Rows.Count)
+            insertIndex = sections[sectionIndex].Rows.Count;
 
         var row = new DesignerRow();
         row.Fields.Add(new DesignerField { FieldType = fieldType });
-        rows.Insert(insertIndex, row);
+        sections[sectionIndex].Rows.Insert(insertIndex, row);
         StateHasChanged();
-        await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
+        await JS.InvokeVoidAsync("initSortable", $"#section-{sectionIndex}-rows", objRef!);
+    }
+
+    [JSInvokable]
+    public void OnSectionReorder(int oldIndex, int newIndex)
+    {
+        if (oldIndex == newIndex || oldIndex < 0 || newIndex < 0 || oldIndex >= sections.Count || newIndex >= sections.Count)
+            return;
+        var item = sections[oldIndex];
+        sections.RemoveAt(oldIndex);
+        sections.Insert(newIndex, item);
+        StateHasChanged();
+    }
+
+    void ToggleCollapse(int index)
+    {
+        sections[index].IsCollapsed = !sections[index].IsCollapsed;
+    }
+
+    async Task DeleteSection(int index)
+    {
+        bool? confirm = await DialogService.Confirm(
+            "Delete this section and all its fields?",
+            "Delete Section",
+            new ConfirmOptions { OkButtonText = "Yes", CancelButtonText = "No" });
+        if (confirm == true)
+        {
+            sections.RemoveAt(index);
+            await JS.InvokeVoidAsync("initSectionSortable", "#sections-container", objRef!);
+        }
+    }
+
+    List<object> BuildFieldPayload()
+    {
+        var list = new List<object>();
+        int rowCounter = 0;
+        foreach (var sec in sections)
+        {
+            list.Add(new
+            {
+                Label = sec.Title,
+                FieldType = "section",
+                IsRequired = false,
+                Row = rowCounter,
+                Column = 0,
+                OptionsJson = string.IsNullOrWhiteSpace(sec.Instructions) ? null :
+                    JsonSerializer.Serialize(new { Instructions = sec.Instructions })
+            });
+            rowCounter++;
+
+            foreach (var row in sec.Rows)
+            {
+                for (int c = 0; c < row.Fields.Count; c++)
+                {
+                    var f = row.Fields[c];
+                    list.Add(new
+                    {
+                        f.Label,
+                        f.FieldType,
+                        f.IsRequired,
+                        Row = rowCounter,
+                        Column = c,
+                        OptionsJson = JsonSerializer.Serialize(
+                            f.OptionItems.Count > 0 ? f.OptionItems :
+                            f.GridRows.Count > 0 || f.GridColumns.Count > 0 ? new { Rows = f.GridRows, Columns = f.GridColumns } :
+                            f.FieldType == "scale" ? new { Min = f.ScaleMin, Max = f.ScaleMax } :
+                            !string.IsNullOrWhiteSpace(f.Instructions) ? new { Instructions = f.Instructions } :
+                            new object()
+                        )
+                    });
+                }
+                rowCounter++;
+            }
+        }
+        return list;
     }
 
     async Task HandleSubmit()
@@ -303,7 +430,7 @@ else
             return;
         }
 
-        foreach (var f in rows.SelectMany(r => r.Fields))
+        foreach (var f in sections.SelectMany(s => s.Rows).SelectMany(r => r.Fields))
         {
             if (string.IsNullOrWhiteSpace(f.Label))
             {
@@ -336,19 +463,7 @@ else
             NotifyOnResponse = notifyOnResponse,
             NotificationEmail = string.IsNullOrWhiteSpace(notificationEmail) ? null : notificationEmail,
             IsActive = true,
-            Fields = rows.SelectMany((row, rIdx) => row.Fields.Select((f, cIdx) => new
-            {
-                f.Label,
-                f.FieldType,
-                f.IsRequired,
-                Row = rIdx,
-                Column = cIdx,
-                OptionsJson = JsonSerializer.Serialize(
-                    f.OptionItems.Count > 0 ? f.OptionItems :
-                    f.GridRows.Count > 0 || f.GridColumns.Count > 0 ? new { Rows = f.GridRows, Columns = f.GridColumns } :
-                    f.FieldType == "scale" ? new { Min = f.ScaleMin, Max = f.ScaleMax } : new object()
-                )
-            })).ToList()
+            Fields = BuildFieldPayload()
         };
 
         var resp = await Http.PostAsJsonAsync("api/forms", payload);
@@ -371,19 +486,7 @@ else
             NotifyOnResponse = notifyOnResponse,
             NotificationEmail = string.IsNullOrWhiteSpace(notificationEmail) ? null : notificationEmail,
             IsDraft = true,
-            Fields = rows.SelectMany((row, rIdx) => row.Fields.Select((f, cIdx) => new
-            {
-                f.Label,
-                f.FieldType,
-                f.IsRequired,
-                Row = rIdx,
-                Column = cIdx,
-                OptionsJson = JsonSerializer.Serialize(
-                    f.OptionItems.Count > 0 ? f.OptionItems :
-                    f.GridRows.Count > 0 || f.GridColumns.Count > 0 ? new { Rows = f.GridRows, Columns = f.GridColumns } :
-                    f.FieldType == "scale" ? new { Min = f.ScaleMin, Max = f.ScaleMax } : new object()
-                )
-            })).ToList()
+            Fields = BuildFieldPayload()
         };
 
         await Http.PostAsJsonAsync("api/forms", payload);
@@ -404,7 +507,7 @@ else
             return;
         }
 
-        if (rows.SelectMany(r => r.Fields).Count() >= 2)
+        if (sections.SelectMany(s => s.Rows).SelectMany(r => r.Fields).Count() >= 2)
         {
             context.PreventNavigation();
             bool? save = await DialogService.Confirm(

--- a/Client/Pages/DynamicForms/Index.razor
+++ b/Client/Pages/DynamicForms/Index.razor
@@ -240,6 +240,13 @@ else
         await JS.InvokeVoidAsync("initSortable", $"#section-{sections.Count - 1}-rows", objRef!);
     }
 
+    DesignerField CreateField(string fieldType) => new DesignerField
+    {
+        FieldType = fieldType,
+        Placeholder = fieldType == "text" ? "Short answer" :
+                      fieldType == "textarea" ? "Paragraph" : string.Empty
+    };
+
     async Task AddField(int section, int row, string fieldType = "text")
     {
         if (sections[section].Rows[row].Fields.Count >= 4)
@@ -252,7 +259,7 @@ else
             });
             return;
         }
-        sections[section].Rows[row].Fields.Add(new DesignerField { FieldType = fieldType });
+        sections[section].Rows[row].Fields.Add(CreateField(fieldType));
         await JS.InvokeVoidAsync("initSortable", $"#section-{section}-rows", objRef!);
     }
 
@@ -278,7 +285,8 @@ else
             GridColumns = new List<string>(field.GridColumns),
             GridRows = new List<string>(field.GridRows),
             ScaleMin = field.ScaleMin,
-            ScaleMax = field.ScaleMax
+            ScaleMax = field.ScaleMax,
+            Placeholder = field.Placeholder
         };
         var list = sections[section].Rows[row].Fields;
         if (list.Count >= 4)
@@ -305,7 +313,7 @@ else
             rowIndex = sections[sectionIndex].Rows.Count - 1;
 
         var list = sections[sectionIndex].Rows[rowIndex].Fields;
-        var field = new DesignerField { FieldType = fieldType };
+        var field = CreateField(fieldType);
 
         if (list.Count >= 4)
         {
@@ -337,7 +345,7 @@ else
             insertIndex = sections[sectionIndex].Rows.Count;
 
         var row = new DesignerRow();
-        row.Fields.Add(new DesignerField { FieldType = fieldType });
+        row.Fields.Add(CreateField(fieldType));
         sections[sectionIndex].Rows.Insert(insertIndex, row);
         StateHasChanged();
         await JS.InvokeVoidAsync("initSortable", $"#section-{sectionIndex}-rows", objRef!);
@@ -399,6 +407,7 @@ else
                     {
                         f.Label,
                         f.FieldType,
+                        f.Placeholder,
                         f.IsRequired,
                         Row = rowCounter,
                         Column = c,

--- a/NdaProcesses.Shared/DesignerField.cs
+++ b/NdaProcesses.Shared/DesignerField.cs
@@ -6,6 +6,7 @@
         public string Label { get; set; } = string.Empty;
         public string FieldType { get; set; } = "text";
         public string Instructions { get; set; } = string.Empty;
+        public string Placeholder { get; set; } = string.Empty;
         public bool IsRequired { get; set; }
 
         // Dynamic options

--- a/NdaProcesses.Shared/DesignerField.cs
+++ b/NdaProcesses.Shared/DesignerField.cs
@@ -5,6 +5,7 @@
         public string Key { get; set; } = string.Empty;
         public string Label { get; set; } = string.Empty;
         public string FieldType { get; set; } = "text";
+        public string Instructions { get; set; } = string.Empty;
         public bool IsRequired { get; set; }
 
         // Dynamic options

--- a/NdaProcesses.Shared/DesignerSection.cs
+++ b/NdaProcesses.Shared/DesignerSection.cs
@@ -1,0 +1,11 @@
+namespace DynamicFormsApp.Shared
+{
+    public class DesignerSection
+    {
+        public string Key { get; set; } = string.Empty;
+        public string Title { get; set; } = string.Empty;
+        public string Instructions { get; set; } = string.Empty;
+        public bool IsCollapsed { get; set; }
+        public List<DesignerRow> Rows { get; set; } = new() { new DesignerRow() };
+    }
+}

--- a/NdaProcesses.Shared/Models/CreateFieldDto.cs
+++ b/NdaProcesses.Shared/Models/CreateFieldDto.cs
@@ -5,6 +5,7 @@ namespace DynamicFormsApp.Shared.Models
         public string? Key { get; set; }
         public string Label { get; set; } = string.Empty;
         public string FieldType { get; set; } = "text";
+        public string? Placeholder { get; set; }
         public bool IsRequired { get; set; }
         public string? OptionsJson { get; set; }
         public int? Row { get; set; }

--- a/NdaProcesses.Shared/Models/FormField.cs
+++ b/NdaProcesses.Shared/Models/FormField.cs
@@ -9,6 +9,7 @@ namespace DynamicFormsApp.Shared.Models
         public string Key { get; set; }      // SQL column name
         public string Label { get; set; }    // UI label
         public string FieldType { get; set; }// e.g., "text","number","dropdown", etc.
+        public string? Placeholder { get; set; }
         public bool IsRequired { get; set; }
 
         // Optional: for dropdowns, checkboxes, grids, etc.

--- a/Server/Components/App.razor
+++ b/Server/Components/App.razor
@@ -24,12 +24,12 @@
     <script src="_framework/blazor.web.js?v=@AppInfo.Version"></script>
     <script src="_content/Radzen.Blazor/Radzen.Blazor.js?v=@(typeof(Radzen.Colors).Assembly.GetName().Version)&app=@AppInfo.Version"></script>
     <script>navigator.serviceWorker.register('service-worker.js?v=@AppInfo.Version');</script>
-    <script src="js/cookieHelper.js"></script>
+    <script src="js/cookieHelper.js?v=@AppInfo.Version"></script>
     <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
-    <script src="js/sortable-wrapper.js"></script>
-    <script src="js/dragdrop-wrapper.js"></script>
-    <script src="js/chartInterop.js"></script>
-    <script type="module" src="js/exportHelper.js"></script>
+    <script src="js/sortable-wrapper.js?v=@AppInfo.Version"></script>
+    <script src="js/dragdrop-wrapper.js?v=@AppInfo.Version"></script>
+    <script src="js/chartInterop.js?v=@AppInfo.Version"></script>
+    <script type="module" src="js/exportHelper.js?v=@AppInfo.Version"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>

--- a/Server/Services/DynamicFormService.cs
+++ b/Server/Services/DynamicFormService.cs
@@ -124,11 +124,14 @@ namespace DynamicFormsApp.Server.Services
 
                     var rawName = SanitizeKey(existing.Name);
                     var tableName = $"Form_{existing.Id}_{rawName}";
-                    var sqlType = MapToSqlType(newField.FieldType);
-                    // Existing response rows may prevent adding a NOT NULL column.
-                    // Always allow nulls for new columns to avoid migration issues.
-                    var sql = $"ALTER TABLE [{tableName}] ADD [{newField.Key}] {sqlType} NULL;";
-                    await _db.Database.ExecuteSqlRawAsync(sql);
+                    if (newField.FieldType != "section" && newField.FieldType != "title")
+                    {
+                        var sqlType = MapToSqlType(newField.FieldType);
+                        // Existing response rows may prevent adding a NOT NULL column.
+                        // Always allow nulls for new columns to avoid migration issues.
+                        var sql = $"ALTER TABLE [{tableName}] ADD [{newField.Key}] {sqlType} NULL;";
+                        await _db.Database.ExecuteSqlRawAsync(sql);
+                    }
                 }
             }
 
@@ -184,6 +187,8 @@ namespace DynamicFormsApp.Server.Services
 
             foreach (var fld in form.Fields)
             {
+                if (fld.FieldType == "section" || fld.FieldType == "title")
+                    continue;
                 sb.Append($", [{fld.Key}] {MapToSqlType(fld.FieldType)} {(fld.IsRequired ? "NOT NULL" : "NULL")}");
             }
             sb.Append(");");
@@ -212,21 +217,22 @@ namespace DynamicFormsApp.Server.Services
             var rawName = SanitizeKey(form.Name);
             var tableName = $"Form_{formId}_{rawName}";
 
-            var cols = string.Join(", ", values.Keys.Select(k => $"[{k}]")) + ", CreatedAt";
-            var paramNames = string.Join(", ",
-                values.Keys.Select((k, i) => $"@p{i}")
-                           .Concat(new[] { "@p_created" }));
-            if (form.RequireLogin)
-            {
-                cols += ", ResponderName";
-                paramNames += ", @p_responder";
-            }
+            var validFields = form.Fields
+                .Where(f => f.FieldType != "section" && f.FieldType != "title")
+                .Select(f => f.Key)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
-            var sql = $"INSERT INTO [{tableName}] ({cols}) VALUES ({paramNames});";
+            var filtered = values
+                .Where(kv => validFields.Contains(kv.Key))
+                .ToDictionary(k => k.Key, v => v.Value);
+
+            var cols = string.Join(", ", filtered.Keys.Select(k => $"[{k}]"));
+            var paramNames = string.Join(", ",
+                filtered.Keys.Select((k, i) => $"@p{i}"));
 
             var sqlParams = new List<SqlParameter>();
             int idx = 0;
-            foreach (var kv in values)
+            foreach (var kv in filtered)
             {
                 object raw = kv.Value;
                 if (raw is JsonElement je)
@@ -254,11 +260,18 @@ namespace DynamicFormsApp.Server.Services
                 idx++;
             }
 
+            cols = string.IsNullOrEmpty(cols) ? "CreatedAt" : cols + ", CreatedAt";
+            paramNames = string.IsNullOrEmpty(paramNames) ? "@p_created" : paramNames + ", @p_created";
             sqlParams.Add(new SqlParameter("@p_created", DateTime.UtcNow));
+
             if (form.RequireLogin)
             {
+                cols += ", ResponderName";
+                paramNames += ", @p_responder";
                 sqlParams.Add(new SqlParameter("@p_responder", (object?)responderName ?? DBNull.Value));
             }
+
+            var sql = $"INSERT INTO [{tableName}] ({cols}) VALUES ({paramNames});";
             await _db.Database.ExecuteSqlRawAsync(sql, sqlParams.ToArray());
 
             return form;

--- a/Server/Services/DynamicFormService.cs
+++ b/Server/Services/DynamicFormService.cs
@@ -101,6 +101,7 @@ namespace DynamicFormsApp.Server.Services
                 {
                     match.Label = fld.Label;
                     match.FieldType = fld.FieldType;
+                    match.Placeholder = fld.Placeholder;
                     match.IsRequired = fld.IsRequired;
                     match.OptionsJson = fld.OptionsJson;
                     match.Row = fld.Row;
@@ -115,6 +116,7 @@ namespace DynamicFormsApp.Server.Services
                         Key = key,
                         Label = fld.Label,
                         FieldType = fld.FieldType,
+                        Placeholder = fld.Placeholder,
                         IsRequired = fld.IsRequired,
                         OptionsJson = fld.OptionsJson,
                         Row = fld.Row,
@@ -165,6 +167,7 @@ namespace DynamicFormsApp.Server.Services
                     Key = GetUniqueKey(keySource, keySet),
                     Label = fld.Label,
                     FieldType = fld.FieldType,
+                    Placeholder = fld.Placeholder,
                     IsRequired = fld.IsRequired,
                     OptionsJson = fld.OptionsJson,
                     Row = fld.Row,

--- a/Server/wwwroot/js/dragdrop-wrapper.js
+++ b/Server/wwwroot/js/dragdrop-wrapper.js
@@ -29,24 +29,27 @@ window.initFieldDragDrop = (canvasSelector, dotnetHelper) => {
         const zone = e.target.closest('.row-dropzone');
         if (zone) {
             const insertIndex = parseInt(zone.getAttribute('data-insert'));
-            dotnetHelper.invokeMethodAsync('AddRowFromDrop', type, insertIndex);
+            const sec = parseInt(zone.getAttribute('data-section'));
+            dotnetHelper.invokeMethodAsync('AddRowFromDrop', type, sec, insertIndex);
             return;
         }
 
         const rowEl = e.target.closest('.designer-row');
         let rowIndex = -1;
+        let secIndex = -1;
         let colIndex = -1;
         if (rowEl) {
-            const rows = Array.from(canvas.querySelectorAll('.designer-row'));
-            rowIndex = rows.indexOf(rowEl);
+            const sectionEl = rowEl.closest('.section-wrapper');
+            if (sectionEl) secIndex = parseInt(sectionEl.getAttribute('data-section'));
+            rowIndex = parseInt(rowEl.getAttribute('data-row'));
             const colEl = e.target.closest('[data-id]');
             if (colEl) {
                 colIndex = parseInt(colEl.getAttribute('data-id'));
             }
         }
-        dotnetHelper.invokeMethodAsync('AddFieldFromDrop', type, rowIndex, colIndex);
+        dotnetHelper.invokeMethodAsync('AddFieldFromDrop', type, secIndex, rowIndex, colIndex);
     });
-}; 
+};
 
 // Backwards compatibility
 window.initDragDrop = window.initFieldDragDrop;

--- a/Server/wwwroot/js/sortable-wrapper.js
+++ b/Server/wwwroot/js/sortable-wrapper.js
@@ -19,9 +19,24 @@ window.initSortable = (selector, dotnetHelper) => {
             onEnd: function (evt) {
                 const fromRow = evt.from.getAttribute('data-row');
                 const toRow = evt.to.getAttribute('data-row');
-                dotnetHelper.invokeMethodAsync('OnSortUpdate', parseInt(fromRow), evt.oldIndex, parseInt(toRow), evt.newIndex);
+                const fromSection = evt.from.getAttribute('data-section');
+                const toSection = evt.to.getAttribute('data-section');
+                dotnetHelper.invokeMethodAsync('OnSortUpdate', parseInt(fromSection), parseInt(fromRow), evt.oldIndex, parseInt(toSection), parseInt(toRow), evt.newIndex);
             }
         });
+    });
+};
+
+window.initSectionSortable = (selector, dotnetHelper) => {
+    const container = document.querySelector(selector);
+    if (!container || container.dataset.sectionSortableInit === 'true') return;
+    container.dataset.sectionSortableInit = 'true';
+    new Sortable(container, {
+        animation: 150,
+        handle: '.section-drag-handle',
+        draggable: '.section-wrapper',
+        filter: '.section-dropzone, .section-dropzone *',
+        onEnd: evt => dotnetHelper.invokeMethodAsync('OnSectionReorder', evt.oldIndex, evt.newIndex)
     });
 };
 


### PR DESCRIPTION
## Summary
- cache bust JS assets with version query strings to ensure `initSectionSortable` loads
- specify `.section-wrapper` elements as draggables so sections reorder correctly
- add section headings back into payload so forms display section names
- show section instructions in the renderer
- avoid creating DB columns for section or title fields
- remove default section label, support editing sections on the edit page
- ignore section and title fields when collecting or storing responses to prevent DB column errors

## Testing
- `dotnet build DynamicFormsApp.sln`


------
https://chatgpt.com/codex/tasks/task_e_68837eeab99c832981bcf08cf5bfe70e