### PR TITLE
Interactive preview and undo-redo controls

### DIFF
--- a/Client/Components/BreadcrumbNav.razor
+++ b/Client/Components/BreadcrumbNav.razor
@@ -1,20 +1,22 @@
 @inject NavigationManager Navigation
+@inject HttpClient Http
 @using Microsoft.AspNetCore.Components.Routing
 @using System.Globalization
+@using DynamicFormsApp.Shared.Models
 @implements IDisposable
 @code {
     private List<(string Label, string Path)> items = new();
 
-    protected override void OnInitialized()
+    protected override async Task OnInitializedAsync()
     {
-        Build();
+        await BuildAsync();
         Navigation.LocationChanged += OnLocationChanged;
     }
 
-    private void OnLocationChanged(object? sender, LocationChangedEventArgs e)
+    private async void OnLocationChanged(object? sender, LocationChangedEventArgs e)
     {
-        Build();
-        InvokeAsync(StateHasChanged);
+        await BuildAsync();
+        await InvokeAsync(StateHasChanged);
     }
 
     void IDisposable.Dispose()
@@ -22,7 +24,7 @@
         Navigation.LocationChanged -= OnLocationChanged;
     }
 
-    private void Build()
+    private async Task BuildAsync()
     {
         items.Clear();
         var rel = Navigation.ToBaseRelativePath(Navigation.Uri);
@@ -30,16 +32,30 @@
         rel = rel.Split('?',2)[0];
         var segs = rel.Split('/', StringSplitOptions.RemoveEmptyEntries);
         var path = string.Empty;
+        string? prev = null;
         foreach (var seg in segs)
         {
             path += "/" + seg;
-            items.Add((Format(seg), path));
+            var label = await FormatAsync(seg, prev);
+            items.Add((label, path));
+            prev = seg;
         }
     }
 
-    private static string Format(string seg)
+    private async Task<string> FormatAsync(string seg, string? prev)
     {
         seg = seg.Split('?',2)[0];
+        if (int.TryParse(seg, out var id) && string.Equals(prev, "forms", StringComparison.OrdinalIgnoreCase))
+        {
+            try
+            {
+                var form = await Http.GetFromJsonAsync<Form>($"api/forms/{id}");
+                if (!string.IsNullOrWhiteSpace(form?.Name))
+                    return form.Name;
+            }
+            catch { }
+            return seg;
+        }
         if (int.TryParse(seg, out _)) return seg;
         var text = seg.Replace('-', ' ');
         return CultureInfo.CurrentCulture.TextInfo.ToTitleCase(text);

--- a/Client/Components/FieldEditor.razor
+++ b/Client/Components/FieldEditor.razor
@@ -1,8 +1,10 @@
 ﻿@using Microsoft.AspNetCore.Components
 @using Microsoft.AspNetCore.Components.Forms
 @using DynamicFormsApp.Shared
+@using Microsoft.JSInterop
 @inject IJSRuntime JS
 @inject HttpClient Http
+@implements IDisposable
 
 <div class="card mb-3 shadow-sm field-card" @attributes="AdditionalAttributes">
     <div class="card-body">
@@ -124,16 +126,8 @@
                 <InputFile OnChange="OnImageSelected" />
                 @if (!string.IsNullOrWhiteSpace(Field.ImageUrl))
                 {
-                    <img src="/@Field.ImageUrl" class="mt-2" style="@GetImageStyle()" />
-                    <div class="row mt-2">
-                        <div class="col">
-                            <label class="form-label">Width (px)</label>
-                            <input type="number" class="form-control" @bind="Field.ImageWidth" />
-                        </div>
-                        <div class="col">
-                            <label class="form-label">Height (px)</label>
-                            <input type="number" class="form-control" @bind="Field.ImageHeight" />
-                        </div>
+                    <div class="image-resize-wrapper mt-2" @ref="imageContainerRef">
+                        <img src="/@Field.ImageUrl" style="@GetImageStyle()" />
                     </div>
                 }
             </div>
@@ -157,6 +151,9 @@
     public Dictionary<string, object> AdditionalAttributes { get; set; } = new();
 
     ElementReference optionsRef;
+    ElementReference imageContainerRef;
+    bool imageResizeInit;
+    DotNetObjectReference<FieldEditor>? objRef;
 
     string GetTypeLabel(string type) => type switch
     {
@@ -183,6 +180,16 @@
 
     string GetImageStyle() =>
         $"max-width:100%;{(Field.ImageWidth.HasValue ? $"width:{Field.ImageWidth}px;" : string.Empty)}{(Field.ImageHeight.HasValue ? $"height:{Field.ImageHeight}px;" : string.Empty)}";
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (Field.FieldType == "image" && !string.IsNullOrWhiteSpace(Field.ImageUrl) && !imageResizeInit)
+        {
+            imageResizeInit = true;
+            objRef = DotNetObjectReference.Create(this);
+            await JS.InvokeVoidAsync("initImageResize", imageContainerRef, objRef);
+        }
+    }
 
     void MoveOptionUp(int index)
     {
@@ -254,11 +261,28 @@
         {
             var result = await response.Content.ReadFromJsonAsync<UploadResult>();
             Field.ImageUrl = result?.filePath ?? string.Empty;
+            Field.ImageWidth = null;
+            Field.ImageHeight = null;
+            imageResizeInit = false;
+            await InvokeAsync(StateHasChanged);
         }
+    }
+
+    [JSInvokable]
+    public async Task OnImageResized(double width, double height)
+    {
+        Field.ImageWidth = (int)width;
+        Field.ImageHeight = (int)height;
+        await InvokeAsync(StateHasChanged);
     }
 
     class UploadResult
     {
         public string? filePath { get; set; }
+    }
+
+    public void Dispose()
+    {
+        objRef?.Dispose();
     }
 }

--- a/Client/Components/FieldEditor.razor
+++ b/Client/Components/FieldEditor.razor
@@ -272,6 +272,12 @@
 
     async Task PromptImageUpload()
     {
+        Field.ImageUrl = string.Empty;
+        Field.Key = string.Empty;
+        Field.Label = string.Empty;
+        Field.ImageWidth = null;
+        Field.ImageHeight = null;
+        await InvokeAsync(StateHasChanged);
         await JS.InvokeVoidAsync("triggerClick", imageInput?.Element);
     }
 

--- a/Client/Components/FieldEditor.razor
+++ b/Client/Components/FieldEditor.razor
@@ -1,13 +1,16 @@
 ﻿@using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Forms
 @using DynamicFormsApp.Shared
+@inject IJSRuntime JS
+@inject HttpClient Http
 
 <div class="card mb-3 shadow-sm field-card" @attributes="AdditionalAttributes">
     <div class="card-body">
-
         <div class="d-flex justify-content-between mb-2">
             <div class="d-flex align-items-center gap-2">
                 <span class="drag-handle text-muted"><span class="material-icons fs-4">drag_indicator</span></span>
                 <input class="form-control form-control-sm" placeholder="Field label" @bind="Field.Label" />
+                <span class="badge bg-secondary">@GetTypeLabel(Field.FieldType)</span>
             </div>
             <div class="d-flex gap-2">
                 <button class="btn btn-sm btn-outline-secondary" @onclick="() => OnDuplicate.InvokeAsync(Field)">
@@ -19,70 +22,85 @@
             </div>
         </div>
 
-        <div class="row g-2">
-            <div class="col-md-4">
-                <select class="form-select" @bind="Field.FieldType">
-                    <option value="text">Short Answer</option>
-                    <option value="textarea">Paragraph</option>
-                    <option value="radio">Multiple Choice</option>
-                    <option value="checkbox">Checkbox</option>
-                    <option value="dropdown">Dropdown</option>
-                    <option value="date">Date</option>
-                    <option value="time">Time</option>
-                    <option value="datetime">Date Time</option>
-                    <option value="scale">Linear Scale</option>
-                    <option value="grid_radio">Multiple Choice Grid</option>
-                    <option value="grid_checkbox">Checkbox Grid</option>
-                    <option value="title">Title</option>
-                    <option value="section">Section</option>
-                    <option value="file">Upload File</option>
-                </select>
+        @if (Field.FieldType is "text" or "textarea")
+        {
+            <div class="mb-3">
+                <label class="form-label">Placeholder Text</label>
+                <input class="form-control" @bind="Field.Placeholder" placeholder="e.g., Enter your answer" />
+                <div class="form-text">Shown inside the field until the user enters a value.</div>
             </div>
-        </div>
+            <div class="mb-3">
+                <label class="form-label">Character Limits</label>
+                <div class="d-flex gap-2">
+                    <input type="number" class="form-control form-control-sm" style="width:6rem;" @bind="Field.MinCharLimit" min="0" placeholder="Min" />
+                    <input type="number" class="form-control form-control-sm" style="width:6rem;" @bind="Field.CharLimit" min="1" placeholder="Max" />
+                </div>
+            </div>
+        }
 
         @if (Field.FieldType is "radio" or "checkbox" or "dropdown")
         {
             <label class="form-label mt-3">Options</label>
-            @foreach (var (opt, index) in Field.OptionItems.Select((val, idx) => (val, idx)))
-            {
-                <div class="input-group mb-1">
-                    <input class="form-control" value="@opt" @onchange="e => Field.OptionItems[index] = e.Value?.ToString() ?? string.Empty" />
-                    <button class="btn btn-outline-danger" @onclick="() => Field.OptionItems.RemoveAt(index)">×</button>
-                </div>
-            }
-
-            <button class="btn btn-sm btn-outline-primary" @onclick="() => Field.OptionItems.Add(string.Empty)">
-                + Add Option
-            </button>
+            <div @ref="optionsRef">
+                @foreach (var (opt, index) in Field.OptionItems.Select((val, idx) => (val, idx)))
+                {
+                    <div class="d-flex align-items-center mb-1">
+                        <input class="form-control flex-grow-1" @bind="Field.OptionItems[index]" />
+                        <div class="btn-group btn-group-sm ms-1">
+                            <button class="btn btn-outline-secondary" @onclick="() => MoveOptionUp(index)"><span class="material-icons">arrow_upward</span></button>
+                            <button class="btn btn-outline-secondary" @onclick="() => MoveOptionDown(index)"><span class="material-icons">arrow_downward</span></button>
+                        </div>
+                        <button class="btn btn-outline-danger btn-sm ms-1" @onclick="() => Field.OptionItems.RemoveAt(index)">×</button>
+                    </div>
+                }
+            </div>
+            <div class="d-flex gap-2 mt-1">
+                <button class="btn btn-sm btn-outline-primary" @onclick="AddOption">+ Add Option</button>
+                <button class="btn btn-sm btn-outline-secondary" @onclick="SortOptions">Sort A-Z</button>
+            </div>
         }
         else if (Field.FieldType.StartsWith("grid"))
         {
             <div class="row mt-3">
                 <div class="col-md-6">
                     <label class="form-label">Grid Rows</label>
-                    @foreach (var (row, idx) in Field.GridRows.Select((r, i) => (r, i)))
-                    {
-                        <div class="input-group mb-1">
-                            <input class="form-control" @bind="Field.GridRows[idx]" />
-                            <button class="btn btn-outline-danger" @onclick="() => Field.GridRows.RemoveAt(idx)">×</button>
-                        </div>
-                    }
-                    <button class="btn btn-sm btn-outline-primary" @onclick="() => Field.GridRows.Add(string.Empty)">
-                        + Add Row
-                    </button>
+                    <div>
+                        @foreach (var (row, idx) in Field.GridRows.Select((r, i) => (r, i)))
+                        {
+                            <div class="d-flex align-items-center mb-1">
+                                <input class="form-control flex-grow-1" @bind="Field.GridRows[idx]" />
+                                <div class="btn-group btn-group-sm ms-1">
+                                    <button class="btn btn-outline-secondary" @onclick="() => MoveRowUp(idx)"><span class="material-icons">arrow_upward</span></button>
+                                    <button class="btn btn-outline-secondary" @onclick="() => MoveRowDown(idx)"><span class="material-icons">arrow_downward</span></button>
+                                </div>
+                                <button class="btn btn-outline-danger btn-sm ms-1" @onclick="() => Field.GridRows.RemoveAt(idx)">×</button>
+                            </div>
+                        }
+                    </div>
+                    <div class="d-flex gap-2 mt-1">
+                        <button class="btn btn-sm btn-outline-primary" @onclick="() => Field.GridRows.Add(string.Empty)">+ Add Row</button>
+                        <button class="btn btn-sm btn-outline-secondary" @onclick="SortRows">Sort A-Z</button>
+                    </div>
                 </div>
                 <div class="col-md-6">
                     <label class="form-label">Grid Columns</label>
-                    @foreach (var (col, idx) in Field.GridColumns.Select((c, i) => (c, i)))
-                    {
-                        <div class="input-group mb-1">
-                            <input class="form-control" @bind="Field.GridColumns[idx]" />
-                            <button class="btn btn-outline-danger" @onclick="() => Field.GridColumns.RemoveAt(idx)">×</button>
-                        </div>
-                    }
-                    <button class="btn btn-sm btn-outline-primary" @onclick="() => Field.GridColumns.Add(string.Empty)">
-                        + Add Column
-                    </button>
+                    <div>
+                        @foreach (var (col, idx) in Field.GridColumns.Select((c, i) => (c, i)))
+                        {
+                            <div class="d-flex align-items-center mb-1">
+                                <input class="form-control flex-grow-1" @bind="Field.GridColumns[idx]" />
+                                <div class="btn-group btn-group-sm ms-1">
+                                    <button class="btn btn-outline-secondary" @onclick="() => MoveColumnUp(idx)"><span class="material-icons">arrow_upward</span></button>
+                                    <button class="btn btn-outline-secondary" @onclick="() => MoveColumnDown(idx)"><span class="material-icons">arrow_downward</span></button>
+                                </div>
+                                <button class="btn btn-outline-danger btn-sm ms-1" @onclick="() => Field.GridColumns.RemoveAt(idx)">×</button>
+                            </div>
+                        }
+                    </div>
+                    <div class="d-flex gap-2 mt-1">
+                        <button class="btn btn-sm btn-outline-primary" @onclick="() => Field.GridColumns.Add(string.Empty)">+ Add Column</button>
+                        <button class="btn btn-sm btn-outline-secondary" @onclick="SortColumns">Sort A-Z</button>
+                    </div>
                 </div>
             </div>
         }
@@ -99,8 +117,19 @@
                 </div>
             </div>
         }
+        else if (Field.FieldType == "image")
+        {
+            <div class="mb-3">
+                <label class="form-label">Upload Image</label>
+                <InputFile OnChange="OnImageSelected" />
+                @if (!string.IsNullOrWhiteSpace(Field.ImageUrl))
+                {
+                    <img src="/@Field.ImageUrl" class="img-fluid mt-2" />
+                }
+            </div>
+        }
 
-        @if (Field.FieldType != "title" && Field.FieldType != "section")
+        @if (Field.FieldType != "title" && Field.FieldType != "section" && Field.FieldType != "image")
         {
             <div class="form-check mt-3">
                 <input class="form-check-input" type="checkbox" @bind="Field.IsRequired" />
@@ -116,4 +145,107 @@
     [Parameter] public EventCallback<DesignerField> OnDuplicate { get; set; }
     [Parameter(CaptureUnmatchedValues = true)]
     public Dictionary<string, object> AdditionalAttributes { get; set; } = new();
+
+    ElementReference optionsRef;
+
+    string GetTypeLabel(string type) => type switch
+    {
+        "text" => "Short Answer",
+        "textarea" => "Paragraph",
+        "radio" => "Multiple Choice",
+        "checkbox" => "Checkbox",
+        "dropdown" => "Dropdown",
+        "user" => "User Dropdown",
+        "department" => "Department Dropdown",
+        "location" => "Location Dropdown",
+        "date" => "Date",
+        "time" => "Time",
+        "datetime" => "Date Time",
+        "scale" => "Linear Scale",
+        "grid_radio" => "Choice Grid",
+        "grid_checkbox" => "Checkbox Grid",
+        "title" => "Title",
+        "section" => "Section",
+        "file" => "Upload File",
+        "image" => "Image",
+        _ => type
+    };
+
+    void MoveOptionUp(int index)
+    {
+        if (index <= 0) return;
+        (Field.OptionItems[index - 1], Field.OptionItems[index]) = (Field.OptionItems[index], Field.OptionItems[index - 1]);
+    }
+
+    void MoveOptionDown(int index)
+    {
+        if (index >= Field.OptionItems.Count - 1) return;
+        (Field.OptionItems[index + 1], Field.OptionItems[index]) = (Field.OptionItems[index], Field.OptionItems[index + 1]);
+    }
+
+    void MoveRowUp(int index)
+    {
+        if (index <= 0) return;
+        (Field.GridRows[index - 1], Field.GridRows[index]) = (Field.GridRows[index], Field.GridRows[index - 1]);
+    }
+
+    void MoveRowDown(int index)
+    {
+        if (index >= Field.GridRows.Count - 1) return;
+        (Field.GridRows[index + 1], Field.GridRows[index]) = (Field.GridRows[index], Field.GridRows[index + 1]);
+    }
+
+    void MoveColumnUp(int index)
+    {
+        if (index <= 0) return;
+        (Field.GridColumns[index - 1], Field.GridColumns[index]) = (Field.GridColumns[index], Field.GridColumns[index - 1]);
+    }
+
+    void MoveColumnDown(int index)
+    {
+        if (index >= Field.GridColumns.Count - 1) return;
+        (Field.GridColumns[index + 1], Field.GridColumns[index]) = (Field.GridColumns[index], Field.GridColumns[index + 1]);
+    }
+
+    void SortOptions()
+    {
+        Field.OptionItems = Field.OptionItems.OrderBy(o => o, StringComparer.OrdinalIgnoreCase).ToList();
+    }
+
+    void SortRows()
+    {
+        Field.GridRows = Field.GridRows.OrderBy(o => o, StringComparer.OrdinalIgnoreCase).ToList();
+    }
+
+    void SortColumns()
+    {
+        Field.GridColumns = Field.GridColumns.OrderBy(o => o, StringComparer.OrdinalIgnoreCase).ToList();
+    }
+
+    async Task AddOption()
+    {
+        Field.OptionItems.Add(string.Empty);
+        await InvokeAsync(StateHasChanged);
+        await JS.InvokeVoidAsync("focusLastInput", optionsRef);
+    }
+
+    async Task OnImageSelected(InputFileChangeEventArgs e)
+    {
+        var file = e.File;
+        if (file == null) return;
+        var content = new MultipartFormDataContent();
+        var stream = new StreamContent(file.OpenReadStream(maxAllowedSize: 10 * 1024 * 1024));
+        content.Add(stream, "file", file.Name);
+        var response = await Http.PostAsync("api/FileUpload", content);
+        if (response.IsSuccessStatusCode)
+        {
+            var result = await response.Content.ReadFromJsonAsync<UploadResult>();
+            Field.ImageUrl = result?.filePath ?? string.Empty;
+        }
+    }
+
+    class UploadResult
+    {
+        public string? filePath { get; set; }
+    }
 }

--- a/Client/Components/FieldEditor.razor
+++ b/Client/Components/FieldEditor.razor
@@ -2,6 +2,7 @@
 @using Microsoft.AspNetCore.Components.Forms
 @using DynamicFormsApp.Shared
 @using Microsoft.JSInterop
+@using System.IO
 @inject IJSRuntime JS
 @inject HttpClient Http
 @implements IDisposable
@@ -11,7 +12,14 @@
         <div class="d-flex justify-content-between mb-2">
             <div class="d-flex align-items-center gap-2">
                 <span class="drag-handle text-muted"><span class="material-icons fs-4">drag_indicator</span></span>
-                <input class="form-control form-control-sm" placeholder="Field label" @bind="Field.Label" />
+                @if (Field.FieldType == "image")
+                {
+                    <input class="form-control form-control-sm" value="@Field.Label" readonly />
+                }
+                else
+                {
+                    <input class="form-control form-control-sm" placeholder="Field label" @bind="Field.Label" />
+                }
                 <span class="badge bg-secondary">@GetTypeLabel(Field.FieldType)</span>
             </div>
             <div class="d-flex gap-2">
@@ -79,8 +87,7 @@
                             </div>
                         }
                     </div>
-                    <div class="d-flex gap-2 mt-1">
-                        <button class="btn btn-sm btn-outline-primary" @onclick="() => Field.GridRows.Add(string.Empty)">+ Add Row</button>
+                    <div class="mt-1">
                         <button class="btn btn-sm btn-outline-secondary" @onclick="SortRows">Sort A-Z</button>
                     </div>
                 </div>
@@ -99,8 +106,7 @@
                             </div>
                         }
                     </div>
-                    <div class="d-flex gap-2 mt-1">
-                        <button class="btn btn-sm btn-outline-primary" @onclick="() => Field.GridColumns.Add(string.Empty)">+ Add Column</button>
+                    <div class="mt-1">
                         <button class="btn btn-sm btn-outline-secondary" @onclick="SortColumns">Sort A-Z</button>
                     </div>
                 </div>
@@ -122,12 +128,17 @@
         else if (Field.FieldType == "image")
         {
             <div class="mb-3">
-                <label class="form-label">Upload Image</label>
-                <InputFile OnChange="OnImageSelected" />
+                <InputFile OnChange="OnImageSelected" @ref="imageInput" style="display:none" accept="image/*" />
                 @if (!string.IsNullOrWhiteSpace(Field.ImageUrl))
                 {
-                    <div class="image-resize-wrapper mt-2" @ref="imageContainerRef">
+                    <div class="image-resize-wrapper mt-2" @ref="imageContainerRef" @onclick="PromptImageUpload">
                         <img src="/@Field.ImageUrl" style="@GetImageStyle()" />
+                    </div>
+                }
+                else
+                {
+                    <div class="border rounded p-3 text-center" @onclick="PromptImageUpload">
+                        Click to upload image
                     </div>
                 }
             </div>
@@ -152,7 +163,9 @@
 
     ElementReference optionsRef;
     ElementReference imageContainerRef;
+    InputFile? imageInput;
     bool imageResizeInit;
+    bool fileDialogShown;
     DotNetObjectReference<FieldEditor>? objRef;
 
     string GetTypeLabel(string type) => type switch
@@ -183,11 +196,19 @@
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (Field.FieldType == "image" && !string.IsNullOrWhiteSpace(Field.ImageUrl) && !imageResizeInit)
+        if (Field.FieldType == "image")
         {
-            imageResizeInit = true;
-            objRef = DotNetObjectReference.Create(this);
-            await JS.InvokeVoidAsync("initImageResize", imageContainerRef, objRef);
+            if (string.IsNullOrWhiteSpace(Field.ImageUrl) && !fileDialogShown)
+            {
+                fileDialogShown = true;
+                await JS.InvokeVoidAsync("triggerClick", imageInput?.Element);
+            }
+            else if (!string.IsNullOrWhiteSpace(Field.ImageUrl) && !imageResizeInit)
+            {
+                imageResizeInit = true;
+                objRef = DotNetObjectReference.Create(this);
+                await JS.InvokeVoidAsync("initImageResize", imageContainerRef, objRef);
+            }
         }
     }
 
@@ -249,6 +270,11 @@
         await JS.InvokeVoidAsync("focusLastInput", optionsRef);
     }
 
+    async Task PromptImageUpload()
+    {
+        await JS.InvokeVoidAsync("triggerClick", imageInput?.Element);
+    }
+
     async Task OnImageSelected(InputFileChangeEventArgs e)
     {
         var file = e.File;
@@ -261,6 +287,9 @@
         {
             var result = await response.Content.ReadFromJsonAsync<UploadResult>();
             Field.ImageUrl = result?.filePath ?? string.Empty;
+            var baseName = Path.GetFileNameWithoutExtension(file.Name);
+            Field.Label = baseName;
+            Field.Key = baseName.Replace(" ", "_").ToLowerInvariant();
             Field.ImageWidth = null;
             Field.ImageHeight = null;
             imageResizeInit = false;

--- a/Client/Components/FieldEditor.razor
+++ b/Client/Components/FieldEditor.razor
@@ -124,7 +124,17 @@
                 <InputFile OnChange="OnImageSelected" />
                 @if (!string.IsNullOrWhiteSpace(Field.ImageUrl))
                 {
-                    <img src="/@Field.ImageUrl" class="img-fluid mt-2" />
+                    <img src="/@Field.ImageUrl" class="mt-2" style="@GetImageStyle()" />
+                    <div class="row mt-2">
+                        <div class="col">
+                            <label class="form-label">Width (px)</label>
+                            <input type="number" class="form-control" @bind="Field.ImageWidth" />
+                        </div>
+                        <div class="col">
+                            <label class="form-label">Height (px)</label>
+                            <input type="number" class="form-control" @bind="Field.ImageHeight" />
+                        </div>
+                    </div>
                 }
             </div>
         }
@@ -170,6 +180,9 @@
         "image" => "Image",
         _ => type
     };
+
+    string GetImageStyle() =>
+        $"max-width:100%;{(Field.ImageWidth.HasValue ? $"width:{Field.ImageWidth}px;" : string.Empty)}{(Field.ImageHeight.HasValue ? $"height:{Field.ImageHeight}px;" : string.Empty)}";
 
     void MoveOptionUp(int index)
     {

--- a/Client/Components/LivePreview.razor
+++ b/Client/Components/LivePreview.razor
@@ -1,4 +1,4 @@
-﻿@using DynamicFormsApp.Shared
+@using DynamicFormsApp.Shared
 
 <h5 class="text-muted">Live Preview</h5>
 @if (!string.IsNullOrWhiteSpace(FormName))
@@ -6,128 +6,149 @@
     <h3 class="mb-3">@FormName</h3>
 }
 
-@foreach (var row in Rows)
+@foreach (var section in Sections)
 {
-    <div class="row g-3 mb-3">
-    @foreach (var field in row.Fields)
-    {
-        <div class="col-12 col-md-@(12 / (row.Fields.Count == 0 ? 1 : row.Fields.Count)) mb-3">
-            @if (field.FieldType != "title" && field.FieldType != "section")
-            {
-                <label class="form-label">@field.Label</label>
-            }
-
-        @switch (field.FieldType)
+    <div class="mb-4">
+        <hr />
+        @if (!string.IsNullOrWhiteSpace(section.Title))
         {
-            case "text":
-                <input class="form-control" placeholder="Short answer" disabled />
-                break;
-
-            case "textarea":
-                <textarea class="form-control" placeholder="Paragraph" disabled></textarea>
-                break;
-
-            case "radio":
-                @foreach (var opt in field.OptionItems)
-                {
-                    <div class="form-check">
-                        <input class="form-check-input" type="radio" disabled />
-                        <label class="form-check-label">@opt</label>
-                    </div>
-                }
-                break;
-
-            case "checkbox":
-                @foreach (var opt in field.OptionItems)
-                {
-                    <div class="form-check">
-                        <input class="form-check-input" type="checkbox" disabled />
-                        <label class="form-check-label">@opt</label>
-                    </div>
-                }
-                break;
-
-            case "dropdown":
-                <select class="form-select" disabled>
-                    @foreach (var opt in field.OptionItems)
+            <h5>@(section.Title)</h5>
+        }
+        @if (!string.IsNullOrWhiteSpace(section.Instructions))
+        {
+            <p class="text-muted">@(section.Instructions)</p>
+        }
+        @foreach (var row in section.Rows)
+        {
+            <div class="row g-3 mb-3">
+            @foreach (var field in row.Fields)
+            {
+                <div class="col-12 col-md-@(12 / (row.Fields.Count == 0 ? 1 : row.Fields.Count)) mb-3">
+                    @if (field.FieldType != "title" && field.FieldType != "section" && field.FieldType != "image")
                     {
-                        <option>@opt</option>
+                        <label class="form-label">@field.Label</label>
                     }
-                </select>
-                break;
-
-            case "scale":
-                <div class="d-flex align-items-center gap-3">
-                    @for (int i = field.ScaleMin; i <= field.ScaleMax; i++)
+                    @switch (field.FieldType)
                     {
-                        <div class="form-check">
-                            <input type="radio" disabled class="form-check-input" />
-                            <label class="form-check-label">@i</label>
-                        </div>
+                        case "text":
+                            <input class="form-control" placeholder="@(!string.IsNullOrWhiteSpace(field.Placeholder) ? field.Placeholder : "Short answer")" maxlength="@field.CharLimit" minlength="@field.MinCharLimit" />
+                            break;
+        
+                        case "textarea":
+                            <textarea class="form-control" placeholder="@(!string.IsNullOrWhiteSpace(field.Placeholder) ? field.Placeholder : "Paragraph")" maxlength="@field.CharLimit" minlength="@field.MinCharLimit"></textarea>
+                            break;
+                        case "radio":
+                            @foreach (var opt in field.OptionItems)
+                            {
+                                <div class="form-check">
+                                    <input class="form-check-input" type="radio" name="@field.Key" />
+                                    <label class="form-check-label">@opt</label>
+                                </div>
+                            }
+                            break;
+                        case "checkbox":
+                            @foreach (var opt in field.OptionItems)
+                            {
+                                <div class="form-check">
+                                    <input class="form-check-input" type="checkbox" />
+                                    <label class="form-check-label">@opt</label>
+                                </div>
+                            }
+                            break;
+                        case "dropdown":
+                            <select class="form-select">
+                                <option>@(!string.IsNullOrWhiteSpace(field.Placeholder) ? field.Placeholder : "Select one from dropdown")</option>
+                                @foreach (var opt in field.OptionItems)
+                                {
+                                    <option>@opt</option>
+                                }
+                            </select>
+                            break;
+                        case "user":
+                            <select class="form-select">
+                                <option>Select user</option>
+                            </select>
+                            break;
+                        case "department":
+                            <select class="form-select">
+                                <option>Select department</option>
+                            </select>
+                            break;
+                        case "location":
+                            <select class="form-select">
+                                <option>Select location</option>
+                            </select>
+                            break;
+                        case "scale":
+                            <div class="d-flex align-items-center gap-3">
+                                @for (int i = field.ScaleMin; i <= field.ScaleMax; i++)
+                                {
+                                    <div class="form-check">
+                                        <input type="radio" class="form-check-input" name="scale-@field.Key" />
+                                        <label class="form-check-label">@i</label>
+                                    </div>
+                                }
+                            </div>
+                            break;
+                        case "grid_radio":
+                        case "grid_checkbox":
+                            <table class="table table-bordered table-sm">
+                                <thead>
+                                    <tr>
+                                        <th></th>
+                                        @foreach (var col in field.GridColumns)
+                                        {
+                                            <th>@col</th>
+                                        }
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @foreach (var gridRow in field.GridRows)
+                                    {
+                                        <tr>
+                                            <td><strong>@gridRow</strong></td>
+                                            @foreach (var col in field.GridColumns)
+                                            {
+                                                <td>
+                                                    @if (field.FieldType == "grid_radio")
+                                                    {
+                                                        <input type="radio" name="@($"grid-{field.Key}-{gridRow}")" />
+                                                    }
+                                                    else
+                                                    {
+                                                        <input type="checkbox" />
+                                                    }
+                                                </td>
+                                            }
+                                        </tr>
+                                    }
+                                </tbody>
+                            </table>
+                            break;
+                        case "file":
+                            <input type="file" class="form-control" />
+                            break;
+                        case "image":
+                            @if (!string.IsNullOrWhiteSpace(field.ImageUrl))
+                            {
+                                <img src="/@field.ImageUrl" class="img-fluid" />
+                            }
+                            break;
+                        case "title":
+                            <h4 class="text-muted">@field.Label</h4>
+                            break;
+                        default:
+                            <input class="form-control" />
+                            break;
                     }
                 </div>
-                break;
-
-            case "grid_radio":
-            case "grid_checkbox":
-                <table class="table table-bordered table-sm">
-                    <thead>
-                        <tr>
-                            <th></th>
-                            @foreach (var col in field.GridColumns)
-                            {
-                                <th>@col</th>
-                            }
-                        </tr>
-                    </thead>
-                    <tbody>
-                        @foreach (var gridRow in field.GridRows)
-                        {
-                            <tr>
-                                <td><strong>@gridRow</strong></td>
-                                @foreach (var col in field.GridColumns)
-                                {
-                                    <td>
-                                        @if (field.FieldType == "grid_radio")
-                                        {
-                                            <input type="radio" disabled />
-                                        }
-                                        else
-                                        {
-                                            <input type="checkbox" disabled />
-                                        }
-                                    </td>
-                                }
-                            </tr>
-                        }
-                    </tbody>
-                </table>
-                break;
-
-            case "file":
-                <input type="file" class="form-control" disabled />
-                break;
-
-            case "title":
-                <h4 class="text-muted">@field.Label</h4>
-                break;
-
-            case "section":
-                <hr />
-                <h5>@field.Label</h5>
-                break;
-
-            default:
-                <input class="form-control" disabled />
-                break;
+            }
+            </div>
         }
-
-        </div>
-    }
     </div>
 }
 
 @code {
-    [Parameter] public List<DesignerRow> Rows { get; set; } = new();
+    [Parameter] public List<DesignerSection> Sections { get; set; } = new();
     [Parameter] public string? FormName { get; set; }
 }

--- a/Client/Components/LivePreview.razor
+++ b/Client/Components/LivePreview.razor
@@ -131,7 +131,7 @@
                         case "image":
                             @if (!string.IsNullOrWhiteSpace(field.ImageUrl))
                             {
-                                <img src="/@field.ImageUrl" class="img-fluid" />
+                                <img src="/@field.ImageUrl" style="@GetImageStyle(field)" />
                             }
                             break;
                         case "title":
@@ -151,4 +151,7 @@
 @code {
     [Parameter] public List<DesignerSection> Sections { get; set; } = new();
     [Parameter] public string? FormName { get; set; }
+
+    string GetImageStyle(DesignerField f) =>
+        $"max-width:100%;{(f.ImageWidth.HasValue ? $"width:{f.ImageWidth}px;" : string.Empty)}{(f.ImageHeight.HasValue ? $"height:{f.ImageHeight}px;" : string.Empty)}";
 }

--- a/Client/Pages/DynamicForms/EditFormPage.razor
+++ b/Client/Pages/DynamicForms/EditFormPage.razor
@@ -154,15 +154,9 @@ else if (!string.IsNullOrEmpty(deletedMessage))
                                                                  OnDuplicate="async f => await DuplicateField(secIndex, rowIndex, f)" />
                                                 </div>
                                             }
-                                            <div class="col-12 no-drop">
-                                                <button class="btn btn-sm btn-primary" @onclick="() => AddField(secIndex, rowIndex)">+ Add Column</button>
-                                            </div>
                                         </div>
                                     }
                                     <div class="row-dropzone" data-section="@secIndex" data-insert="@sections[secIndex].Rows.Count"></div>
-                                    <div class="d-grid mb-3">
-                                        <button class="btn btn-primary" @onclick="() => AddRow(secIndex)">+ Add Row</button>
-                                    </div>
                                 </div>
                             </div>
                         </div>
@@ -412,13 +406,6 @@ public void OnSortUpdate(int fromSection, int fromRow, int oldIndex, int toSecti
     }
 }
 
-async Task AddRow(int section)
-{
-    PushUndo();
-    sections[section].Rows.Add(new DesignerRow());
-    await JS.InvokeVoidAsync("initSortable", $"#section-{section}-rows", objRef!);
-}
-
     DesignerField CreateField(string fieldType) => new DesignerField
     {
         FieldType = fieldType,
@@ -440,24 +427,6 @@ async Task AddRow(int section)
                       fieldType == "textarea" ? "Paragraph" :
                       fieldType == "dropdown" ? "Select one from dropdown" : string.Empty
     };
-
-async Task AddField(int section, int row, string fieldType = "text")
-{
-    if (sections[section].Rows[row].Fields.Count >= 4)
-    {
-        NotificationService.Notify(new NotificationMessage
-        {
-            Severity = NotificationSeverity.Warning,
-            Summary = "Column limit reached",
-            Detail = "A row can contain at most four columns."
-        });
-        return;
-    }
-    PushUndo();
-    sections[section].Rows[row].Fields.Add(CreateField(fieldType));
-    await JS.InvokeVoidAsync("initSortable", $"#section-{section}-rows", objRef!);
-    await JS.InvokeVoidAsync("focusFieldLabel", section, row, sections[section].Rows[row].Fields.Count - 1);
-}
 
     async Task RemoveField(int section, int row, DesignerField field)
     {

--- a/Client/Pages/DynamicForms/EditFormPage.razor
+++ b/Client/Pages/DynamicForms/EditFormPage.razor
@@ -2,6 +2,7 @@
 @using System.Net.Http.Json
 @using System.Net
 @using System.Text.Json
+@using System.Collections.Generic
 @using DynamicFormsApp.Client.Components
 @using DynamicFormsApp.Shared
 @using DynamicFormsApp.Shared.Models
@@ -24,33 +25,10 @@ else if (!string.IsNullOrEmpty(deletedMessage))
 }
 <p class="text-muted">Drag fields to reorder or move them between rows. Each row can have up to four columns.</p>
 
-<div class="form-check form-switch mb-4">
-    <input class="form-check-input" type="checkbox" id="previewToggle" @bind="isPreviewMode" />
-    <label class="form-check-label" for="previewToggle">Preview Mode</label>
-</div>
-
-<div class="mb-4">
-    <label class="form-label">Form Name</label>
-    <input class="form-control form-control-lg" placeholder="Enter your form title" @bind="formName" />
-</div>
-<div class="mb-4">
-    <label class="form-label">Description</label>
-    <textarea class="form-control"  placeholder="Enter a description" @bind="formDescription"></textarea>
-</div>
-
-<div class="form-check form-switch mb-4">
-    <input class="form-check-input" type="checkbox" id="loginToggle" @bind="requireLogin" />
-    <label class="form-check-label" for="loginToggle">Require login to access form</label>
-</div>
-<div class="form-check form-switch mb-4">
-    <input class="form-check-input" type="checkbox" id="notifyToggle" @bind="notifyOnResponse" />
-    <label class="form-check-label" for="notifyToggle">Email on new response</label>
-</div>
-@if (notifyOnResponse)
+@if (isPreviewMode)
 {
     <div class="mb-3">
-        <label class="form-label">Notification Email</label>
-        <input class="form-control" placeholder="@currentUser?.Email" @bind="notificationEmail" />
+        <button class="btn btn-secondary btn-sm" @onclick="TogglePreview">Building</button>
     </div>
 }
 
@@ -58,7 +36,18 @@ else if (!string.IsNullOrEmpty(deletedMessage))
 {
     <div class="row">
         <div class="col-md-3" style="position:sticky;top:75px;max-height:calc(100vh - 90px);overflow-y:auto;">
-            <h5 class="mb-3">Toolbox</h5>
+            <div class="mb-3 d-flex align-items-center gap-2">
+                <h5 class="mb-0">Toolbox</h5>
+                <div class="ms-auto d-flex gap-2">
+                    <button class="btn btn-secondary btn-sm" @onclick="Undo" disabled="@(!undoStack.Any())">
+                        <span class="material-icons">undo</span>
+                    </button>
+                    <button class="btn btn-secondary btn-sm" @onclick="Redo" disabled="@(!redoStack.Any())">
+                        <span class="material-icons">redo</span>
+                    </button>
+                    <button class="btn btn-secondary btn-sm" @onclick="TogglePreview">Preview</button>
+                </div>
+            </div>
             <div class="d-flex flex-wrap gap-2">
                 <div class="draggable-field" draggable="true" data-type="text"><span class="material-icons me-1">short_text</span> Short Answer</div>
                 <div class="draggable-field" draggable="true" data-type="textarea"><span class="material-icons me-1">notes</span> Paragraph</div>
@@ -74,31 +63,114 @@ else if (!string.IsNullOrEmpty(deletedMessage))
                 <div class="draggable-field" draggable="true" data-type="title"><span class="material-icons me-1">title</span> Title</div>
                 <div class="draggable-field" draggable="true" data-type="section"><span class="material-icons me-1">view_headline</span> Section</div>
                 <div class="draggable-field" draggable="true" data-type="file"><span class="material-icons me-1">upload_file</span> Upload File</div>
+                <div class="draggable-field" draggable="true" data-type="image"><span class="material-icons me-1">image</span> Image</div>
+            </div>
+            <h6 class="mt-3">User Fields</h6>
+            <div class="d-flex flex-wrap gap-2">
+                <div class="draggable-field" draggable="true" data-type="user"><span class="material-icons me-1">person</span> User Dropdown</div>
+                <div class="draggable-field" draggable="true" data-type="department"><span class="material-icons me-1">apartment</span> Department Dropdown</div>
+                <div class="draggable-field" draggable="true" data-type="location"><span class="material-icons me-1">location_on</span> Location Dropdown</div>
             </div>
         </div>
         <div class="col-md-9">
-            <div id="fields-container">
-                @for (int r = 0; r < rows.Count; r++)
+            <div class="mb-4">
+                <label class="form-label">Form Name</label>
+                <input class="form-control form-control-lg" placeholder="Enter your form title" @bind="formName" />
+            </div>
+            <div class="mb-4">
+                <label class="form-label">Description</label>
+                <textarea class="form-control"  placeholder="Enter a description" @bind="formDescription"></textarea>
+            </div>
+            <div class="form-check form-switch mb-4">
+                <input class="form-check-input" type="checkbox" id="loginToggle" @bind="requireLogin" disabled="@(SectionsHaveRestrictions())" />
+                <label class="form-check-label" for="loginToggle">Require login to access form</label>
+            </div>
+            <div class="form-check form-switch mb-4">
+                <input class="form-check-input" type="checkbox" id="notifyToggle" @bind="notifyOnResponse" />
+                <label class="form-check-label" for="notifyToggle">Email on new response</label>
+            </div>
+            @if (notifyOnResponse)
+            {
+                <div class="mb-3">
+                    <label class="form-label">Notification Email</label>
+                    <input class="form-control" placeholder="@currentUser?.Email" @bind="notificationEmail" />
+                </div>
+            }
+            <div id="sections-container">
+                @for (int s = 0; s < sections.Count; s++)
                 {
-                    var rowIndex = r;
-                    <div class="row-dropzone" data-insert="@rowIndex"></div>
-                    <div class="row g-3 mb-3 designer-row" data-row="@rowIndex" @key="rows[rowIndex]">
-                        @for (int i = 0; i < rows[rowIndex].Fields.Count; i++)
-                        {
-                            <div class="col-12 col-md-@(12 / (rows[rowIndex].Fields.Count == 0 ? 1 : rows[rowIndex].Fields.Count))" data-id="@i" @key="rows[rowIndex].Fields[i]">
-                                <FieldEditor Field="rows[rowIndex].Fields[i]"
-                                             OnRemove="async f => await RemoveField(rowIndex, f)"
-                                             OnDuplicate="async f => await DuplicateField(rowIndex, f)" />
+                    var secIndex = s;
+                    <div class="section-wrapper mb-4" data-section="@secIndex" id="section-@secIndex" @key="sections[secIndex]">
+                        <div class="card">
+                            <div class="card-header">
+                                <div class="d-flex align-items-center gap-2">
+                                    <span class="material-icons section-drag-handle">drag_indicator</span>
+                                    <input class="form-control form-control-sm" placeholder="Section title" @bind="sections[secIndex].Title" />
+                                    <div class="ms-auto d-flex align-items-center gap-2">
+                                        <div class="d-flex align-items-center gap-1">
+                                            <div class="form-check m-0">
+                                                <input class="form-check-input" type="checkbox" checked="@sections[secIndex].UseDepartmentFilter" @onchange="e => ToggleDepartmentFilter(secIndex, e)" id="edit-sec-@secIndex-dep" title="Check this box to filter this section to specific departments" />
+                                                <label class="form-check-label" for="edit-sec-@secIndex-dep">Department</label>
+                                            </div>
+                                            @if (sections[secIndex].UseDepartmentFilter)
+                                            {
+                                                <RadzenDropDown Data="@deptOptions" Multiple="true" CheckBoxes="true" Style="min-width:120px" Value="@sections[secIndex].Departments" ValueChanged="@((IEnumerable<string> values) => OnDepartmentsChanged(secIndex, values))" class="section-filter-select" />
+                                            }
+                                        </div>
+                                        <div class="d-flex align-items-center gap-1">
+                                            <div class="form-check m-0">
+                                                <input class="form-check-input" type="checkbox" checked="@sections[secIndex].UseLocationFilter" @onchange="e => ToggleLocationFilter(secIndex, e)" id="edit-sec-@secIndex-loc" title="Check this box to filter this section to specific locations" />
+                                                <label class="form-check-label" for="edit-sec-@secIndex-loc">Location</label>
+                                            </div>
+                                            @if (sections[secIndex].UseLocationFilter)
+                                            {
+                                                <RadzenDropDown Data="@locOptions" Multiple="true" CheckBoxes="true" Style="min-width:120px" Value="@sections[secIndex].Locations" ValueChanged="@((IEnumerable<string> values) => OnLocationsChanged(secIndex, values))" class="section-filter-select" />
+                                            }
+                                        </div>
+                                        <div class="d-flex align-items-center gap-1">
+                                            <button class="btn btn-sm btn-outline-secondary" @onclick="() => ToggleCollapse(secIndex)">
+                                                <span class="material-icons">@(!sections[secIndex].IsCollapsed ? "expand_less" : "expand_more")</span>
+                                            </button>
+                                            <button class="btn btn-sm btn-outline-danger" @onclick="() => DeleteSection(secIndex)">
+                                                <span class="material-icons">delete</span>
+                                            </button>
+                                        </div>
+                                    </div>
+                                </div>
                             </div>
-                        }
-                        <div class="col-12 no-drop">
-                            <button class="btn btn-sm btn-primary" @onclick="() => AddField(rowIndex)">+ Add Column</button>
+                            <div class="card-body" hidden="@sections[secIndex].IsCollapsed">
+                                <textarea class="form-control mb-3" placeholder="Section instructions" @bind="sections[secIndex].Instructions"></textarea>
+                                <div id="section-@secIndex-rows">
+                                    @for (int r = 0; r < sections[secIndex].Rows.Count; r++)
+                                    {
+                                        var rowIndex = r;
+                                        <div class="row-dropzone" data-section="@secIndex" data-insert="@rowIndex"></div>
+                                        <div class="row g-3 mb-3 designer-row" data-section="@secIndex" data-row="@rowIndex" @key="sections[secIndex].Rows[rowIndex]">
+                                            @for (int i = 0; i < sections[secIndex].Rows[rowIndex].Fields.Count; i++)
+                                            {
+                                                <div class="col-12 col-md-@(12 / (sections[secIndex].Rows[rowIndex].Fields.Count == 0 ? 1 : sections[secIndex].Rows[rowIndex].Fields.Count))" data-id="@i" @key="sections[secIndex].Rows[rowIndex].Fields[i]">
+                                                    <FieldEditor Field="sections[secIndex].Rows[rowIndex].Fields[i]"
+                                                                 OnRemove="async f => await RemoveField(secIndex, rowIndex, f)"
+                                                                 OnDuplicate="async f => await DuplicateField(secIndex, rowIndex, f)" />
+                                                </div>
+                                            }
+                                            <div class="col-12 no-drop">
+                                                <button class="btn btn-sm btn-primary" @onclick="() => AddField(secIndex, rowIndex)">+ Add Column</button>
+                                            </div>
+                                        </div>
+                                    }
+                                    <div class="row-dropzone" data-section="@secIndex" data-insert="@sections[secIndex].Rows.Count"></div>
+                                    <div class="d-grid mb-3">
+                                        <button class="btn btn-primary" @onclick="() => AddRow(secIndex)">+ Add Row</button>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
                     </div>
                 }
-                <div class="row-dropzone" data-insert="@rows.Count"></div>
+                <div class="section-dropzone" data-insert="@sections.Count"></div>
                 <div class="d-grid mb-3">
-                    <button class="btn btn-primary" @onclick="AddRow">+ Add Row</button>
+                    <button class="btn btn-secondary" @onclick="AddSection">+ Add Section</button>
                 </div>
                 @if (isDraft)
                 {
@@ -121,8 +193,17 @@ else if (!string.IsNullOrEmpty(deletedMessage))
 }
 else
 {
-    <div class="card p-3 shadow-sm">
-        <LivePreview Rows="rows" FormName="@formName" />
+    <div class="row">
+        <div class="col-md-3" style="position:sticky;top:75px;max-height:calc(100vh - 90px);overflow-y:auto;">
+            <div class="mb-3">
+                <h5 class="mb-0">Toolbox</h5>
+            </div>
+        </div>
+        <div class="col-md-9">
+            <div class="card p-3 shadow-sm">
+                <LivePreview Sections="sections" FormName="@formName" />
+            </div>
+        </div>
     </div>
 }
 
@@ -130,7 +211,7 @@ else
     [Parameter] public int FormId { get; set; }
     private string formName = string.Empty;
     private string formDescription = string.Empty;
-    private List<DesignerRow> rows = new() { new DesignerRow() };
+    private List<DesignerSection> sections = new() { new DesignerSection() };
     private bool isPreviewMode = false;
     private bool requireLogin = true;
     private bool notifyOnResponse = false;
@@ -140,6 +221,39 @@ else
     private DotNetObjectReference<DynamicFormsApp.Client.Pages.DynamicForms.EditFormPage>? objRef;
     private string? deletedMessage;
     private DeletedFormInfo? unavailableInfo;
+    private List<string> deptOptions = new();
+    private List<string> locOptions = new();
+    private bool restrictionAlertShown = false;
+
+    private Stack<List<DesignerSection>> undoStack = new();
+    private Stack<List<DesignerSection>> redoStack = new();
+
+    List<DesignerSection> CloneSections(List<DesignerSection> src) =>
+        JsonSerializer.Deserialize<List<DesignerSection>>(JsonSerializer.Serialize(src)) ?? new();
+
+    void PushUndo()
+    {
+        undoStack.Push(CloneSections(sections));
+        redoStack.Clear();
+    }
+
+    void Undo()
+    {
+        if (undoStack.Count == 0) return;
+        redoStack.Push(CloneSections(sections));
+        sections = undoStack.Pop();
+        OnSectionRestrictionChanged();
+    }
+
+    void Redo()
+    {
+        if (redoStack.Count == 0) return;
+        undoStack.Push(CloneSections(sections));
+        sections = redoStack.Pop();
+        OnSectionRestrictionChanged();
+    }
+
+    void TogglePreview() => isPreviewMode = !isPreviewMode;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -155,6 +269,8 @@ else
 
             currentUser = await UserService.GetUserData(user);
             notificationEmail = currentUser?.Email ?? string.Empty;
+            deptOptions = await UserService.GetDepartments();
+            locOptions = await UserService.GetLocations();
 
             var resp = await Http.GetAsync($"api/forms/{FormId}");
             if (!resp.IsSuccessStatusCode)
@@ -178,7 +294,7 @@ else
             notifyOnResponse = form.NotifyOnResponse;
             notificationEmail = form.NotificationEmail ?? notificationEmail;
             isDraft = form.IsDraft;
-            rows = BuildDesignerRows(form);
+            sections = BuildDesignerSections(form);
 
             objRef ??= DotNetObjectReference.Create(this);
             StateHasChanged();
@@ -187,71 +303,163 @@ else
         if (!isPreviewMode)
         {
             objRef ??= DotNetObjectReference.Create(this);
-            await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef);
-            await JS.InvokeVoidAsync("initFieldDragDrop", "#fields-container", objRef);
+            await JS.InvokeVoidAsync("initSectionSortable", "#sections-container", objRef);
+            for (int i = 0; i < sections.Count; i++)
+            {
+                await JS.InvokeVoidAsync("initSortable", $"#section-{i}-rows", objRef);
+            }
+            await JS.InvokeVoidAsync("initFieldDragDrop", "#sections-container", objRef);
         }
     }
 
-    [JSInvokable]
-    public void OnSortUpdate(int fromRow, int oldIndex, int toRow, int newIndex)
+    bool SectionsHaveRestrictions() => sections.Any(s => s.Departments.Any() || s.Locations.Any());
+
+    void OnSectionRestrictionChanged()
     {
-        if (fromRow < 0 || fromRow >= rows.Count || toRow < 0 || toRow >= rows.Count)
-            return;
-
-        var source = rows[fromRow].Fields;
-        var dest = rows[toRow].Fields;
-
-        if (oldIndex < 0 || oldIndex >= source.Count || newIndex < 0 || newIndex > dest.Count)
-            return;
-
-        if (fromRow != toRow && dest.Count >= 4)
+        if (SectionsHaveRestrictions())
         {
-            NotificationService.Notify(new NotificationMessage
+            if (!requireLogin)
+                requireLogin = true;
+            if (!restrictionAlertShown)
             {
-                Severity = NotificationSeverity.Warning,
-                Summary = "Column limit reached",
-                Detail = "A row can contain at most four columns."
-            });
-            StateHasChanged();
-            return;
+                NotificationService.Notify(new NotificationMessage
+                {
+                    Severity = NotificationSeverity.Warning,
+                    Summary = "Login required",
+                    Detail = "Section visibility filters require login to access the form."
+                });
+                restrictionAlertShown = true;
+            }
         }
-
-        var moved = source[oldIndex];
-        source.RemoveAt(oldIndex);
-
-        int insertIndex = Math.Min(newIndex, dest.Count);
-        dest.Insert(insertIndex, moved);
-        if (source.Count == 0 && rows.Count > 1)
+        else
         {
-            rows.RemoveAt(fromRow);
+            restrictionAlertShown = false;
         }
+    }
+
+    void OnDepartmentsChanged(int secIndex, IEnumerable<string> values)
+    {
+        sections[secIndex].Departments = values.ToList();
+        OnSectionRestrictionChanged();
+    }
+
+    void OnLocationsChanged(int secIndex, IEnumerable<string> values)
+    {
+        sections[secIndex].Locations = values.ToList();
+        OnSectionRestrictionChanged();
+    }
+
+    void ToggleDepartmentFilter(int secIndex, ChangeEventArgs e)
+    {
+        sections[secIndex].UseDepartmentFilter = e.Value is bool b && b;
+        if (!sections[secIndex].UseDepartmentFilter)
+            sections[secIndex].Departments.Clear();
+        OnSectionRestrictionChanged();
+    }
+
+    void ToggleLocationFilter(int secIndex, ChangeEventArgs e)
+    {
+        sections[secIndex].UseLocationFilter = e.Value is bool b && b;
+        if (!sections[secIndex].UseLocationFilter)
+            sections[secIndex].Locations.Clear();
+        OnSectionRestrictionChanged();
+    }
+
+
+[JSInvokable]
+public void OnSortUpdate(int fromSection, int fromRow, int oldIndex, int toSection, int toRow, int newIndex)
+{
+    if (fromSection < 0 || fromSection >= sections.Count || toSection < 0 || toSection >= sections.Count)
+        return;
+
+    PushUndo();
+
+    if (fromRow < 0 || fromRow >= sections[fromSection].Rows.Count || toRow < 0 || toRow >= sections[toSection].Rows.Count)
+        return;
+
+    var source = sections[fromSection].Rows[fromRow].Fields;
+    var dest = sections[toSection].Rows[toRow].Fields;
+
+    if (oldIndex < 0 || oldIndex >= source.Count || newIndex < 0 || newIndex > dest.Count)
+        return;
+
+    if (fromRow != toRow && dest.Count >= 4)
+    {
+        NotificationService.Notify(new NotificationMessage
+        {
+            Severity = NotificationSeverity.Warning,
+            Summary = "Column limit reached",
+            Detail = "A row can contain at most four columns."
+        });
         StateHasChanged();
-        JS.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
+        return;
     }
 
-    async Task AddRow()
-    {
-        rows.Add(new DesignerRow());
-        await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
-    }
+    var moved = source[oldIndex];
+    source.RemoveAt(oldIndex);
 
-    async Task AddField(int row)
+    int insertIndex = Math.Min(newIndex, dest.Count);
+    dest.Insert(insertIndex, moved);
+    if (source.Count == 0 && sections[fromSection].Rows.Count > 1)
     {
-        if (rows[row].Fields.Count >= 4)
+        sections[fromSection].Rows.RemoveAt(fromRow);
+    }
+    StateHasChanged();
+    JS.InvokeVoidAsync("initSortable", $"#section-{fromSection}-rows", objRef!);
+    if (fromSection != toSection)
+    {
+        JS.InvokeVoidAsync("initSortable", $"#section-{toSection}-rows", objRef!);
+    }
+}
+
+async Task AddRow(int section)
+{
+    PushUndo();
+    sections[section].Rows.Add(new DesignerRow());
+    await JS.InvokeVoidAsync("initSortable", $"#section-{section}-rows", objRef!);
+}
+
+    DesignerField CreateField(string fieldType) => new DesignerField
+    {
+        FieldType = fieldType,
+        Key = fieldType switch
         {
-            NotificationService.Notify(new NotificationMessage
-            {
-                Severity = NotificationSeverity.Warning,
-                Summary = "Column limit reached",
-                Detail = "A row can contain at most four columns."
-            });
-            return;
-        }
-        rows[row].Fields.Add(new DesignerField());
-        await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
-    }
+            "user" => "select a user",
+            "department" => "department",
+            "location" => "location",
+            _ => string.Empty
+        },
+        Label = fieldType switch
+        {
+            "user" => "Select a user",
+            "department" => "Department",
+            "location" => "Location",
+            _ => string.Empty
+        },
+        Placeholder = fieldType == "text" ? "Short answer" :
+                      fieldType == "textarea" ? "Paragraph" :
+                      fieldType == "dropdown" ? "Select one from dropdown" : string.Empty
+    };
 
-    async Task RemoveField(int row, DesignerField field)
+async Task AddField(int section, int row, string fieldType = "text")
+{
+    if (sections[section].Rows[row].Fields.Count >= 4)
+    {
+        NotificationService.Notify(new NotificationMessage
+        {
+            Severity = NotificationSeverity.Warning,
+            Summary = "Column limit reached",
+            Detail = "A row can contain at most four columns."
+        });
+        return;
+    }
+    PushUndo();
+    sections[section].Rows[row].Fields.Add(CreateField(fieldType));
+    await JS.InvokeVoidAsync("initSortable", $"#section-{section}-rows", objRef!);
+    await JS.InvokeVoidAsync("focusFieldLabel", section, row, sections[section].Rows[row].Fields.Count - 1);
+}
+
+    async Task RemoveField(int section, int row, DesignerField field)
     {
         if (!isDraft)
         {
@@ -264,29 +472,35 @@ else
                 return;
         }
 
-        rows[row].Fields.Remove(field);
-        if (rows[row].Fields.Count == 0 && rows.Count > 1)
+        PushUndo();
+        sections[section].Rows[row].Fields.Remove(field);
+        if (sections[section].Rows[row].Fields.Count == 0 && sections[section].Rows.Count > 1)
         {
-            rows.RemoveAt(row);
+            sections[section].Rows.RemoveAt(row);
         }
-        await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
+        await JS.InvokeVoidAsync("initSortable", $"#section-{section}-rows", objRef!);
     }
 
-    async Task DuplicateField(int row, DesignerField field)
+    async Task DuplicateField(int section, int row, DesignerField field)
     {
+        PushUndo();
         var copy = new DesignerField
         {
-            Key = string.Empty,
+            Key = field.Key,
             Label = field.Label,
             FieldType = field.FieldType,
+            Placeholder = field.Placeholder,
+            CharLimit = field.CharLimit,
+            MinCharLimit = field.MinCharLimit,
             IsRequired = field.IsRequired,
             OptionItems = new List<string>(field.OptionItems),
             GridColumns = new List<string>(field.GridColumns),
             GridRows = new List<string>(field.GridRows),
             ScaleMin = field.ScaleMin,
-            ScaleMax = field.ScaleMax
+            ScaleMax = field.ScaleMax,
+            ImageUrl = field.ImageUrl
         };
-        var list = rows[row].Fields;
+        var list = sections[section].Rows[row].Fields;
         if (list.Count >= 4)
         {
             NotificationService.Notify(new NotificationMessage
@@ -299,17 +513,20 @@ else
         }
 
         list.Insert(list.IndexOf(field) + 1, copy);
-        await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
+        await JS.InvokeVoidAsync("initSortable", $"#section-{section}-rows", objRef!);
     }
 
-    [JSInvokable]
-    public async Task AddFieldFromDrop(string fieldType, int rowIndex, int colIndex)
-    {
-        if (rowIndex < 0 || rowIndex >= rows.Count)
-            rowIndex = rows.Count - 1;
+[JSInvokable]
+public async Task AddFieldFromDrop(string fieldType, int sectionIndex, int rowIndex, int colIndex)
+{
+    PushUndo();
+    if (sectionIndex < 0 || sectionIndex >= sections.Count)
+        sectionIndex = sections.Count - 1;
+    if (rowIndex < 0 || rowIndex >= sections[sectionIndex].Rows.Count)
+        rowIndex = sections[sectionIndex].Rows.Count - 1;
 
-        var list = rows[rowIndex].Fields;
-        var field = new DesignerField { FieldType = fieldType };
+    var list = sections[sectionIndex].Rows[rowIndex].Fields;
+    var field = CreateField(fieldType);
 
         if (list.Count >= 4)
         {
@@ -323,47 +540,196 @@ else
             return;
         }
 
-        if (colIndex < 0 || colIndex > list.Count)
-            list.Add(field);
-        else
-            list.Insert(colIndex, field);
-
-        StateHasChanged();
-        await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
+    int newIndex;
+    if (colIndex < 0 || colIndex > list.Count)
+    {
+        list.Add(field);
+        newIndex = list.Count - 1;
+    }
+    else
+    {
+        list.Insert(colIndex, field);
+        newIndex = colIndex;
     }
 
-    [JSInvokable]
-    public async Task AddRowFromDrop(string fieldType, int insertIndex)
-    {
-        if (insertIndex < 0 || insertIndex > rows.Count)
-            insertIndex = rows.Count;
+    StateHasChanged();
+    await JS.InvokeVoidAsync("initSortable", $"#section-{sectionIndex}-rows", objRef!);
+    await JS.InvokeVoidAsync("focusFieldLabel", sectionIndex, rowIndex, newIndex);
+}
 
-        var row = new DesignerRow();
-        row.Fields.Add(new DesignerField { FieldType = fieldType });
-        rows.Insert(insertIndex, row);
-        StateHasChanged();
-        await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
+async Task AddSection()
+{
+    PushUndo();
+    sections.Add(new DesignerSection());
+    await JS.InvokeVoidAsync("initSectionSortable", "#sections-container", objRef!);
+    await JS.InvokeVoidAsync("initSortable", $"#section-{sections.Count - 1}-rows", objRef!);
+}
+
+[JSInvokable]
+public async Task AddRowFromDrop(string fieldType, int sectionIndex, int insertIndex)
+{
+    PushUndo();
+    if (sectionIndex < 0 || sectionIndex >= sections.Count)
+        sectionIndex = sections.Count - 1;
+    if (insertIndex < 0 || insertIndex > sections[sectionIndex].Rows.Count)
+        insertIndex = sections[sectionIndex].Rows.Count;
+
+    var row = new DesignerRow();
+    row.Fields.Add(CreateField(fieldType));
+    sections[sectionIndex].Rows.Insert(insertIndex, row);
+    StateHasChanged();
+    await JS.InvokeVoidAsync("initSortable", $"#section-{sectionIndex}-rows", objRef!);
+    await JS.InvokeVoidAsync("focusFieldLabel", sectionIndex, insertIndex, 0);
+}
+
+[JSInvokable]
+public void OnSectionReorder(int oldIndex, int newIndex)
+{
+    if (oldIndex == newIndex || oldIndex < 0 || newIndex < 0 || oldIndex >= sections.Count || newIndex >= sections.Count)
+        return;
+    PushUndo();
+    var item = sections[oldIndex];
+    sections.RemoveAt(oldIndex);
+    sections.Insert(newIndex, item);
+    StateHasChanged();
+}
+
+void ToggleCollapse(int index)
+{
+    sections[index].IsCollapsed = !sections[index].IsCollapsed;
+}
+
+async Task DeleteSection(int index)
+{
+    bool? confirm = await DialogService.Confirm(
+        "Delete this section and all its fields?",
+        "Delete Section",
+        new ConfirmOptions { OkButtonText = "Yes", CancelButtonText = "No" });
+    if (confirm == true)
+    {
+        PushUndo();
+        sections.RemoveAt(index);
+        await JS.InvokeVoidAsync("initSectionSortable", "#sections-container", objRef!);
+        OnSectionRestrictionChanged();
     }
+}
 
-    private List<DesignerRow> BuildDesignerRows(Form form)
+List<object> BuildFieldPayload()
+{
+    var list = new List<object>();
+    int rowCounter = 0;
+    foreach (var sec in sections)
     {
-        var result = new List<DesignerRow>();
-        var groups = form.Fields
-            .OrderBy(f => f.Row ?? 0)
-            .ThenBy(f => f.Column ?? 0)
-            .GroupBy(f => f.Row ?? 0);
-
-        foreach (var g in groups)
+        list.Add(new
         {
+            Key = sec.Key,
+            Label = sec.Title,
+            FieldType = "section",
+            IsRequired = false,
+            Row = rowCounter,
+            Column = 0,
+            OptionsJson = (string.IsNullOrWhiteSpace(sec.Instructions) && sec.Departments.Count == 0 && sec.Locations.Count == 0)
+                ? null
+                : JsonSerializer.Serialize(new { Instructions = sec.Instructions, Departments = sec.Departments, Locations = sec.Locations })
+        });
+        rowCounter++;
+
+        foreach (var row in sec.Rows)
+        {
+            for (int c = 0; c < row.Fields.Count; c++)
+            {
+                var f = row.Fields[c];
+                var opts = f.OptionItems.Where(o => !string.IsNullOrWhiteSpace(o)).ToList();
+                var rowsList = f.GridRows.Where(o => !string.IsNullOrWhiteSpace(o)).ToList();
+                var colsList = f.GridColumns.Where(o => !string.IsNullOrWhiteSpace(o)).ToList();
+                string? optionsJson = opts.Count > 0 ? JsonSerializer.Serialize(opts)
+                    : rowsList.Count > 0 || colsList.Count > 0 ? JsonSerializer.Serialize(new { Rows = rowsList, Columns = colsList })
+                    : f.FieldType == "scale" ? JsonSerializer.Serialize(new { Min = f.ScaleMin, Max = f.ScaleMax })
+                    : !string.IsNullOrWhiteSpace(f.Instructions) ? JsonSerializer.Serialize(new { Instructions = f.Instructions })
+                    : null;
+                list.Add(new
+                {
+                    f.Key,
+                    f.Label,
+                    f.FieldType,
+                    f.Placeholder,
+                    f.CharLimit,
+                    f.MinCharLimit,
+                    f.IsRequired,
+                    f.ImageUrl,
+                    Row = rowCounter,
+                    Column = c,
+                    OptionsJson = optionsJson
+                });
+            }
+            rowCounter++;
+        }
+    }
+    return list;
+}
+
+    private List<DesignerSection> BuildDesignerSections(Form form)
+    {
+        var result = new List<DesignerSection>();
+        var ordered = form.Fields.OrderBy(f => f.Row ?? 0).ThenBy(f => f.Column ?? 0).ToList();
+
+        DesignerSection? current = null;
+        foreach (var group in ordered.GroupBy(f => f.Row ?? 0).OrderBy(g => g.Key))
+        {
+            var fields = group.OrderBy(f => f.Column ?? 0).ToList();
+            if (fields.Count == 1 && fields[0].FieldType == "section")
+            {
+                var secField = fields[0];
+                string instr = string.Empty;
+                var deps = new List<string>();
+                var locs = new List<string>();
+                if (!string.IsNullOrWhiteSpace(secField.OptionsJson))
+                {
+                    try
+                    {
+                        using var doc = JsonDocument.Parse(secField.OptionsJson);
+                        if (doc.RootElement.TryGetProperty("Instructions", out var instEl))
+                            instr = instEl.GetString() ?? string.Empty;
+                        if (doc.RootElement.TryGetProperty("Departments", out var depEl) && depEl.ValueKind == JsonValueKind.Array)
+                            deps = depEl.EnumerateArray().Select(e => e.GetString() ?? string.Empty).Where(s => !string.IsNullOrWhiteSpace(s)).ToList();
+                        if (doc.RootElement.TryGetProperty("Locations", out var locEl) && locEl.ValueKind == JsonValueKind.Array)
+                            locs = locEl.EnumerateArray().Select(e => e.GetString() ?? string.Empty).Where(s => !string.IsNullOrWhiteSpace(s)).ToList();
+                    }
+                    catch { }
+                }
+                current = new DesignerSection
+                {
+                    Key = secField.Key,
+                    Title = secField.Label,
+                    Instructions = instr,
+                    UseDepartmentFilter = deps.Count > 0,
+                    UseLocationFilter = locs.Count > 0,
+                    Departments = deps,
+                    Locations = locs
+                };
+                result.Add(current);
+                continue;
+            }
+
+            if (current == null)
+            {
+                current = new DesignerSection();
+                result.Add(current);
+            }
+
             var row = new DesignerRow();
-            foreach (var f in g)
+            foreach (var f in fields)
             {
                 var field = new DesignerField
                 {
                     Key = f.Key,
                     Label = f.Label,
                     FieldType = f.FieldType,
-                    IsRequired = f.IsRequired
+                    Placeholder = f.Placeholder ?? string.Empty,
+                    CharLimit = f.CharLimit,
+                    MinCharLimit = f.MinCharLimit,
+                    IsRequired = f.IsRequired,
+                    ImageUrl = f.ImageUrl ?? string.Empty
                 };
                 if (!string.IsNullOrWhiteSpace(f.OptionsJson))
                 {
@@ -375,12 +741,12 @@ else
                 }
                 row.Fields.Add(field);
             }
-            result.Add(row);
+            current.Rows.Add(row);
         }
 
         if (result.Count == 0)
         {
-            result.Add(new DesignerRow());
+            result.Add(new DesignerSection());
         }
         return result;
     }
@@ -398,9 +764,12 @@ else
             return;
         }
 
-        foreach (var f in rows.SelectMany(r => r.Fields))
+        if (SectionsHaveRestrictions())
+            requireLogin = true;
+
+        foreach (var f in sections.SelectMany(s => s.Rows).SelectMany(r => r.Fields))
         {
-            if (string.IsNullOrWhiteSpace(f.Label))
+            if (f.FieldType != "image" && string.IsNullOrWhiteSpace(f.Label))
             {
                 NotificationService.Notify(new NotificationMessage
                 {
@@ -411,13 +780,26 @@ else
                 return;
             }
 
-            if ((f.FieldType == "radio" || f.FieldType == "checkbox" || f.FieldType == "dropdown") && f.OptionItems.Count == 0)
+            if ((f.FieldType == "radio" || f.FieldType == "checkbox" || f.FieldType == "dropdown") &&
+                !f.OptionItems.Any(o => !string.IsNullOrWhiteSpace(o)))
             {
                 NotificationService.Notify(new NotificationMessage
                 {
                     Severity = NotificationSeverity.Warning,
-                    Summary = "Options required",
+                    Summary = "Options Required",
                     Detail = $"Add at least one option for '{f.Label}'."
+                });
+                return;
+            }
+
+            if ((f.FieldType == "grid_radio" || f.FieldType == "grid_checkbox") &&
+                (!f.GridRows.Any(r => !string.IsNullOrWhiteSpace(r)) || !f.GridColumns.Any(c => !string.IsNullOrWhiteSpace(c))))
+            {
+                NotificationService.Notify(new NotificationMessage
+                {
+                    Severity = NotificationSeverity.Warning,
+                    Summary = "Options Required",
+                    Detail = $"Add at least one row and column for '{f.Label}'."
                 });
                 return;
             }
@@ -432,20 +814,7 @@ else
             NotificationEmail = string.IsNullOrWhiteSpace(notificationEmail) ? null : notificationEmail,
             IsActive = true,
             IsDraft = draft,
-            Fields = rows.SelectMany((row, rIdx) => row.Fields.Select((f, cIdx) => new
-            {
-                f.Key,
-                f.Label,
-                f.FieldType,
-                f.IsRequired,
-                Row = rIdx,
-                Column = cIdx,
-                OptionsJson = JsonSerializer.Serialize(
-                    f.OptionItems.Count > 0 ? f.OptionItems :
-                    f.GridRows.Count > 0 || f.GridColumns.Count > 0 ? new { Rows = f.GridRows, Columns = f.GridColumns } :
-                    f.FieldType == "scale" ? new { Min = f.ScaleMin, Max = f.ScaleMax } : new object()
-                )
-            })).ToList()
+            Fields = BuildFieldPayload()
         };
 
         var resp = await Http.PutAsJsonAsync($"api/forms/{FormId}", payload);

--- a/Client/Pages/DynamicForms/EditFormPage.razor
+++ b/Client/Pages/DynamicForms/EditFormPage.razor
@@ -498,7 +498,9 @@ async Task AddField(int section, int row, string fieldType = "text")
             GridRows = new List<string>(field.GridRows),
             ScaleMin = field.ScaleMin,
             ScaleMax = field.ScaleMax,
-            ImageUrl = field.ImageUrl
+            ImageUrl = field.ImageUrl,
+            ImageWidth = field.ImageWidth,
+            ImageHeight = field.ImageHeight
         };
         var list = sections[section].Rows[row].Fields;
         if (list.Count >= 4)
@@ -657,6 +659,8 @@ List<object> BuildFieldPayload()
                     f.MinCharLimit,
                     f.IsRequired,
                     f.ImageUrl,
+                    f.ImageWidth,
+                    f.ImageHeight,
                     Row = rowCounter,
                     Column = c,
                     OptionsJson = optionsJson
@@ -729,7 +733,9 @@ List<object> BuildFieldPayload()
                     CharLimit = f.CharLimit,
                     MinCharLimit = f.MinCharLimit,
                     IsRequired = f.IsRequired,
-                    ImageUrl = f.ImageUrl ?? string.Empty
+                    ImageUrl = f.ImageUrl ?? string.Empty,
+                    ImageWidth = f.ImageWidth,
+                    ImageHeight = f.ImageHeight
                 };
                 if (!string.IsNullOrWhiteSpace(f.OptionsJson))
                 {

--- a/Client/Pages/DynamicForms/FormRenderer.razor
+++ b/Client/Pages/DynamicForms/FormRenderer.razor
@@ -8,6 +8,7 @@
 @inject HttpClient Http
 @inject NavigationManager Navigation
 @inject CookieHelper CookieHelper
+@inject IUserService UserService
 
 <h3>@(!string.IsNullOrEmpty(statusMessage) || unavailableInfo != null
         ? "Form Not Available"
@@ -54,12 +55,15 @@ else
                 {
                     case "text":
                         <input type="text" class="form-control"
+                               placeholder="@fld.Placeholder"
                                value="@GetString(fld.Key)"
+                               maxlength="@fld.CharLimit"
+                               minlength="@fld.MinCharLimit"
                                @onchange="e => OnTextChanged(fld.Key, e)" />
                         break;
 
                     case "textarea":
-                        <textarea class="form-control"
+                        <textarea class="form-control" placeholder="@fld.Placeholder" maxlength="@fld.CharLimit" minlength="@fld.MinCharLimit"
                                   @onchange="e => OnTextChanged(fld.Key, e)">@GetString(fld.Key)</textarea>
                         break;
 
@@ -90,10 +94,38 @@ else
                     case "dropdown":
                         var ddOptions = JsonSerializer.Deserialize<List<string>>(fld.OptionsJson ?? "[]");
                         <select class="form-select" value="@GetString(fld.Key)" @onchange="e => OnTextChanged(fld.Key, e)">
-                            <option value="" disabled selected>Select...</option>
+                            <option value="" disabled selected>@(string.IsNullOrWhiteSpace(fld.Placeholder) ? "Select one from dropdown" : fld.Placeholder)</option>
                             @foreach (var opt in ddOptions)
                             {
                                 <option value="@opt">@opt</option>
+                            }
+                        </select>
+                        break;
+
+                    case "user":
+                        <select class="form-select" value="@GetString(fld.Key)" @onchange="e => OnTextChanged(fld.Key, e)">
+                            <option value="" disabled selected>Select user...</option>
+                            @foreach (var u in directoryUsers)
+                            {
+                                <option value="@u.DisplayName">@u.DisplayName - @u.Department - @u.Location</option>
+                            }
+                        </select>
+                        break;
+                    case "department":
+                        <select class="form-select" value="@GetString(fld.Key)" @onchange="e => OnTextChanged(fld.Key, e)">
+                            <option value="" disabled selected>Select department...</option>
+                            @foreach (var d in departments)
+                            {
+                                <option value="@d">@d</option>
+                            }
+                        </select>
+                        break;
+                    case "location":
+                        <select class="form-select" value="@GetString(fld.Key)" @onchange="e => OnTextChanged(fld.Key, e)">
+                            <option value="" disabled selected>Select location...</option>
+                            @foreach (var l in locations)
+                            {
+                                <option value="@l">@l</option>
                             }
                         </select>
                         break;
@@ -130,6 +162,12 @@ else
                             <div class="form-text">Uploaded: @responseData[fld.Key]</div>
                         }
                         break;
+                    case "image":
+                        @if (!string.IsNullOrWhiteSpace(fld.ImageUrl))
+                        {
+                            <img src="/@fld.ImageUrl" class="img-fluid" />
+                        }
+                        break;
 
                     case "title":
                         <h4>@fld.Label</h4>
@@ -137,7 +175,14 @@ else
 
                     case "section":
                         <hr />
-                        <h5>@fld.Label</h5>
+                        @if (!string.IsNullOrWhiteSpace(fld.Label))
+                        {
+                            <h5>@fld.Label</h5>
+                        }
+                        @if (!string.IsNullOrWhiteSpace(GetInstructions(fld)))
+                        {
+                            <p class="text-muted">@GetInstructions(fld)</p>
+                        }
                         break;
 
                     case "scale":
@@ -179,6 +224,9 @@ else
 
     private Form form;
     private Dictionary<string, object> responseData = new();
+    private List<UserModel> directoryUsers = new();
+    private List<string> departments = new();
+    private List<string> locations = new();
     private string? statusMessage;
     private DeletedFormInfo? unavailableInfo;
 
@@ -203,7 +251,25 @@ else
 
             form = await resp.Content.ReadFromJsonAsync<Form>();
 
+            if (form.Fields.Any(f => f.FieldType == "user"))
+            {
+                directoryUsers = await UserService.GetAllUsers();
+            }
+            if (form.Fields.Any(f => f.FieldType == "department"))
+            {
+                departments = await UserService.GetDepartments();
+            }
+            if (form.Fields.Any(f => f.FieldType == "location"))
+            {
+                locations = await UserService.GetLocations();
+            }
+
             var user = await CookieHelper.LoginStatus();
+            UserModel? currentUser = null;
+            if (!string.IsNullOrEmpty(user))
+            {
+                currentUser = await UserService.GetUserData(user);
+            }
             if (form.RequireLogin && string.IsNullOrEmpty(user))
             {
                 var ret = Uri.EscapeDataString(Navigation.ToBaseRelativePath(Navigation.Uri));
@@ -211,8 +277,15 @@ else
                 return;
             }
 
+            form.Fields = FilterFieldsBySectionVisibility(form.Fields, currentUser);
+
             foreach (var fld in form.Fields)
             {
+                if (fld.FieldType == "section" || fld.FieldType == "title")
+                {
+                    continue;
+                }
+
                 responseData[fld.Key] = fld.FieldType switch
                 {
                     "checkbox" => new List<string>(),
@@ -234,6 +307,65 @@ else
     string GetDateString(string key) => responseData[key] is DateTime dt ? dt.ToString("yyyy-MM-dd") : "";
     string GetTimeString(string key) => responseData[key] is TimeSpan ts ? ts.ToString(@"hh\:mm") : "";
     string GetDateTimeString(string key) => responseData[key] is DateTime dt ? dt.ToString("yyyy-MM-ddTHH:mm") : "";
+
+    string? GetInstructions(FormField field)
+    {
+        if (string.IsNullOrWhiteSpace(field.OptionsJson))
+            return null;
+        try
+        {
+            using var doc = JsonDocument.Parse(field.OptionsJson);
+            if (doc.RootElement.TryGetProperty("Instructions", out var instEl))
+                return instEl.GetString();
+        }
+        catch { }
+        return null;
+    }
+
+    List<FormField> FilterFieldsBySectionVisibility(IEnumerable<FormField> fields, UserModel? user)
+    {
+        if (user == null) return fields.ToList();
+        var ordered = fields.OrderBy(f => f.Row ?? 0).ThenBy(f => f.Column ?? 0).ToList();
+        var result = new List<FormField>();
+        bool sectionVisible = true;
+        foreach (var fld in ordered)
+        {
+            if (fld.FieldType == "section")
+            {
+                sectionVisible = IsSectionVisible(fld, user);
+                if (sectionVisible)
+                    result.Add(fld);
+                continue;
+            }
+            if (sectionVisible)
+                result.Add(fld);
+        }
+        return result;
+    }
+
+    bool IsSectionVisible(FormField sectionField, UserModel user)
+    {
+        if (string.IsNullOrWhiteSpace(sectionField.OptionsJson))
+            return true;
+        try
+        {
+            using var doc = JsonDocument.Parse(sectionField.OptionsJson);
+            if (doc.RootElement.TryGetProperty("Departments", out var depEl) && depEl.ValueKind == JsonValueKind.Array)
+            {
+                var deps = depEl.EnumerateArray().Select(e => e.GetString()).Where(s => !string.IsNullOrWhiteSpace(s)).ToList();
+                if (deps.Count > 0 && !deps.Any(d => string.Equals(d, user.Department, StringComparison.OrdinalIgnoreCase)))
+                    return false;
+            }
+            if (doc.RootElement.TryGetProperty("Locations", out var locEl) && locEl.ValueKind == JsonValueKind.Array)
+            {
+                var locs = locEl.EnumerateArray().Select(e => e.GetString()).Where(s => !string.IsNullOrWhiteSpace(s)).ToList();
+                if (locs.Count > 0 && !locs.Any(l => string.Equals(l, user.Location, StringComparison.OrdinalIgnoreCase)))
+                    return false;
+            }
+        }
+        catch { }
+        return true;
+    }
 
     void OnTextChanged(string key, ChangeEventArgs e) =>
         responseData[key] = e.Value?.ToString() ?? "";
@@ -314,6 +446,34 @@ else
     {
         foreach (var fld in form.Fields)
         {
+            if (fld.FieldType == "text" || fld.FieldType == "textarea")
+            {
+                if (responseData.TryGetValue(fld.Key, out var valObj) && valObj is string s)
+                {
+                    if (fld.MinCharLimit.HasValue && s.Length < fld.MinCharLimit.Value)
+                    {
+                        NotificationService.Notify(new NotificationMessage
+                        {
+                            Severity = NotificationSeverity.Warning,
+                            Summary = "Character limit",
+                            Detail = $"'{fld.Label}' requires at least {fld.MinCharLimit} characters (currently {s.Length}).",
+                        });
+                        return;
+                    }
+
+                    if (fld.CharLimit.HasValue && s.Length > fld.CharLimit.Value)
+                    {
+                        NotificationService.Notify(new NotificationMessage
+                        {
+                            Severity = NotificationSeverity.Warning,
+                            Summary = "Character limit",
+                            Detail = $"'{fld.Label}' allows {fld.CharLimit} characters (currently {s.Length}).",
+                        });
+                        return;
+                    }
+                }
+            }
+
             if (!fld.IsRequired)
                 continue;
 
@@ -323,13 +483,22 @@ else
                 {
                     Severity = NotificationSeverity.Warning,
                     Summary = "Missing answer",
-                    Detail = $"Please fill out '{fld.Label}'."
+                    Detail = $"Please fill out '{fld.Label}'.",
                 });
                 return;
             }
         }
 
-        await Http.PostAsJsonAsync($"api/forms/{FormId}/responses", responseData);
+        var submitData = responseData
+            .Where(kv =>
+                form.Fields.Any(f =>
+                    f.Key.Equals(kv.Key, StringComparison.OrdinalIgnoreCase) &&
+                    f.FieldType != "section" &&
+                    f.FieldType != "title" &&
+                    f.FieldType != "image"))
+            .ToDictionary(k => k.Key, v => v.Value);
+
+        await Http.PostAsJsonAsync($"api/forms/{FormId}/responses", submitData);
 
         var user = await CookieHelper.LoginStatus();
         if (string.IsNullOrEmpty(user))

--- a/Client/Pages/DynamicForms/FormRenderer.razor
+++ b/Client/Pages/DynamicForms/FormRenderer.razor
@@ -165,7 +165,7 @@ else
                     case "image":
                         @if (!string.IsNullOrWhiteSpace(fld.ImageUrl))
                         {
-                            <img src="/@fld.ImageUrl" class="img-fluid" />
+                            <img src="/@fld.ImageUrl" style="@GetImageStyle(fld)" />
                         }
                         break;
 
@@ -229,6 +229,9 @@ else
     private List<string> locations = new();
     private string? statusMessage;
     private DeletedFormInfo? unavailableInfo;
+
+    string GetImageStyle(FormField f) =>
+        $"max-width:100%;{(f.ImageWidth.HasValue ? $"width:{f.ImageWidth}px;" : string.Empty)}{(f.ImageHeight.HasValue ? $"height:{f.ImageHeight}px;" : string.Empty)}";
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {

--- a/Client/Pages/DynamicForms/FormResponses.razor
+++ b/Client/Pages/DynamicForms/FormResponses.razor
@@ -141,7 +141,9 @@
             }
             responses = await respData.Content.ReadFromJsonAsync<List<Dictionary<string, object>>>();
 
-            var fieldKeys = form.Fields.Select(f => f.Key);
+            var fieldKeys = form.Fields
+                .Where(f => f.FieldType != "section" && f.FieldType != "title" && f.FieldType != "image")
+                .Select(f => f.Key);
             columns = new[] { "ResponseId", "CreatedAt" }
                 .Concat(fieldKeys)
                 .ToArray();

--- a/Client/Pages/DynamicForms/Index.razor
+++ b/Client/Pages/DynamicForms/Index.razor
@@ -1,6 +1,7 @@
 @page "/NewForm"
 @using System.Net.Http.Json
 @using System.Text.Json
+@using System.Collections.Generic
 @using DynamicFormsApp.Client.Components
 @using DynamicFormsApp.Shared
 @using DynamicFormsApp.Shared.Models
@@ -17,33 +18,10 @@
 <h2 class="mb-2">Form Builder</h2>
 <p class="text-muted">Drag fields to reorder or move them between rows. Each row can have up to four columns.</p>
 
-<div class="form-check form-switch mb-4">
-    <input class="form-check-input" type="checkbox" id="previewToggle" @bind="isPreviewMode" />
-    <label class="form-check-label" for="previewToggle">Preview Mode</label>
-</div>
-
-<div class="mb-4">
-    <label class="form-label">Form Name</label>
-    <input class="form-control form-control-lg" placeholder="Enter your form title" @bind="formName" />
-</div>
-<div class="mb-4">
-    <label class="form-label">Description</label>
-    <textarea class="form-control" placeholder="Enter a description" @bind="formDescription"></textarea>
-</div>
-
-<div class="form-check form-switch mb-4">
-    <input class="form-check-input" type="checkbox" id="loginToggle" @bind="requireLogin" />
-    <label class="form-check-label" for="loginToggle">Require login to access form</label>
-</div>
-<div class="form-check form-switch mb-4">
-    <input class="form-check-input" type="checkbox" id="notifyToggle" @bind="notifyOnResponse" />
-    <label class="form-check-label" for="notifyToggle">Email on new response</label>
-</div>
-@if (notifyOnResponse)
+@if (isPreviewMode)
 {
     <div class="mb-3">
-        <label class="form-label">Notification Email</label>
-        <input class="form-control" placeholder="@currentUser?.Email" @bind="notificationEmail" />
+        <button class="btn btn-secondary btn-sm" @onclick="TogglePreview">Building</button>
     </div>
 }
 
@@ -51,7 +29,18 @@
 {
     <div class="row">
         <div class="col-md-3" style="position:sticky;top:75px;max-height:calc(100vh - 90px);overflow-y:auto;">
-            <h5 class="mb-3">Toolbox</h5>
+            <div class="mb-3 d-flex align-items-center gap-2">
+                <h5 class="mb-0">Toolbox</h5>
+                <div class="ms-auto d-flex gap-2">
+                    <button class="btn btn-secondary btn-sm" @onclick="Undo" disabled="@(!undoStack.Any())">
+                        <span class="material-icons">undo</span>
+                    </button>
+                    <button class="btn btn-secondary btn-sm" @onclick="Redo" disabled="@(!redoStack.Any())">
+                        <span class="material-icons">redo</span>
+                    </button>
+                    <button class="btn btn-secondary btn-sm" @onclick="TogglePreview">Preview</button>
+                </div>
+            </div>
             <div class="d-flex flex-wrap gap-2">
                 <div class="draggable-field" draggable="true" data-type="text"><span class="material-icons me-1">short_text</span> Short Answer</div>
                 <div class="draggable-field" draggable="true" data-type="textarea"><span class="material-icons me-1">notes</span> Paragraph</div>
@@ -67,31 +56,114 @@
                 <div class="draggable-field" draggable="true" data-type="title"><span class="material-icons me-1">title</span> Title</div>
                 <div class="draggable-field" draggable="true" data-type="section"><span class="material-icons me-1">view_headline</span> Section</div>
                 <div class="draggable-field" draggable="true" data-type="file"><span class="material-icons me-1">upload_file</span> Upload File</div>
+                <div class="draggable-field" draggable="true" data-type="image"><span class="material-icons me-1">image</span> Image</div>
+            </div>
+            <h6 class="mt-3">User Fields</h6>
+            <div class="d-flex flex-wrap gap-2">
+                <div class="draggable-field" draggable="true" data-type="user"><span class="material-icons me-1">person</span> User Dropdown</div>
+                <div class="draggable-field" draggable="true" data-type="department"><span class="material-icons me-1">apartment</span> Department Dropdown</div>
+                <div class="draggable-field" draggable="true" data-type="location"><span class="material-icons me-1">location_on</span> Location Dropdown</div>
             </div>
         </div>
         <div class="col-md-9">
-            <div id="fields-container">
-                @for (int r = 0; r < rows.Count; r++)
+            <div class="mb-4">
+                <label class="form-label">Form Name</label>
+                <input class="form-control form-control-lg" placeholder="Enter your form title" @bind="formName" />
+            </div>
+            <div class="mb-4">
+                <label class="form-label">Description</label>
+                <textarea class="form-control" placeholder="Enter a description" @bind="formDescription"></textarea>
+            </div>
+            <div class="form-check form-switch mb-4">
+                <input class="form-check-input" type="checkbox" id="loginToggle" @bind="requireLogin" disabled="@(SectionsHaveRestrictions())" />
+                <label class="form-check-label" for="loginToggle">Require login to access form</label>
+            </div>
+            <div class="form-check form-switch mb-4">
+                <input class="form-check-input" type="checkbox" id="notifyToggle" @bind="notifyOnResponse" />
+                <label class="form-check-label" for="notifyToggle">Email on new response</label>
+            </div>
+            @if (notifyOnResponse)
+            {
+                <div class="mb-3">
+                    <label class="form-label">Notification Email</label>
+                    <input class="form-control" placeholder="@currentUser?.Email" @bind="notificationEmail" />
+                </div>
+            }
+            <div id="sections-container">
+                @for (int s = 0; s < sections.Count; s++)
                 {
-                    var rowIndex = r;
-                    <div class="row-dropzone" data-insert="@rowIndex"></div>
-                    <div class="row g-3 mb-3 designer-row" data-row="@rowIndex" @key="rows[rowIndex]">
-                        @for (int i = 0; i < rows[rowIndex].Fields.Count; i++)
-                        {
-                            <div class="col-12 col-md-@(12 / (rows[rowIndex].Fields.Count == 0 ? 1 : rows[rowIndex].Fields.Count))" data-id="@i" @key="rows[rowIndex].Fields[i]">
-                                <FieldEditor Field="rows[rowIndex].Fields[i]"
-                                             OnRemove="async f => await RemoveField(rowIndex, f)"
-                                             OnDuplicate="async f => await DuplicateField(rowIndex, f)" />
+                    var secIndex = s;
+                    <div class="section-wrapper mb-4" data-section="@secIndex" id="section-@secIndex" @key="sections[secIndex]">
+                        <div class="card">
+                            <div class="card-header">
+                                <div class="d-flex align-items-center gap-2">
+                                    <span class="material-icons section-drag-handle">drag_indicator</span>
+                                    <input class="form-control form-control-sm" placeholder="Section title" @bind="sections[secIndex].Title" />
+                                    <div class="ms-auto d-flex align-items-center gap-2">
+                                        <div class="d-flex align-items-center gap-1">
+                                            <div class="form-check m-0">
+                                                <input class="form-check-input" type="checkbox" checked="@sections[secIndex].UseDepartmentFilter" @onchange="e => ToggleDepartmentFilter(secIndex, e)" id="sec-@secIndex-dep" title="Check this box to filter this section to specific departments" />
+                                                <label class="form-check-label" for="sec-@secIndex-dep">Department</label>
+                                            </div>
+                                            @if (sections[secIndex].UseDepartmentFilter)
+                                            {
+                                                <RadzenDropDown Data="@deptOptions" Multiple="true" CheckBoxes="true" Style="min-width:120px" Value="@sections[secIndex].Departments" ValueChanged="@((IEnumerable<string> values) => OnDepartmentsChanged(secIndex, values))" class="section-filter-select" />
+                                            }
+                                        </div>
+                                        <div class="d-flex align-items-center gap-1">
+                                            <div class="form-check m-0">
+                                                <input class="form-check-input" type="checkbox" checked="@sections[secIndex].UseLocationFilter" @onchange="e => ToggleLocationFilter(secIndex, e)" id="sec-@secIndex-loc" title="Check this box to filter this section to specific locations" />
+                                                <label class="form-check-label" for="sec-@secIndex-loc">Location</label>
+                                            </div>
+                                            @if (sections[secIndex].UseLocationFilter)
+                                            {
+                                                <RadzenDropDown Data="@locOptions" Multiple="true" CheckBoxes="true" Style="min-width:120px" Value="@sections[secIndex].Locations" ValueChanged="@((IEnumerable<string> values) => OnLocationsChanged(secIndex, values))" class="section-filter-select" />
+                                            }
+                                        </div>
+                                        <div class="d-flex align-items-center gap-1">
+                                            <button class="btn btn-sm btn-outline-secondary" @onclick="() => ToggleCollapse(secIndex)">
+                                                <span class="material-icons">@(!sections[secIndex].IsCollapsed ? "expand_less" : "expand_more")</span>
+                                            </button>
+                                            <button class="btn btn-sm btn-outline-danger" @onclick="() => DeleteSection(secIndex)">
+                                                <span class="material-icons">delete</span>
+                                            </button>
+                                        </div>
+                                    </div>
+                                </div>
                             </div>
-                        }
-                        <div class="col-12 no-drop">
-                            <button class="btn btn-sm btn-primary" @onclick="() => AddField(rowIndex)">+ Add Column</button>
+                            <div class="card-body" hidden="@sections[secIndex].IsCollapsed">
+                                <textarea class="form-control mb-3" placeholder="Section instructions" @bind="sections[secIndex].Instructions"></textarea>
+                                <div id="section-@secIndex-rows">
+                                    @for (int r = 0; r < sections[secIndex].Rows.Count; r++)
+                                    {
+                                        var rowIndex = r;
+                                        <div class="row-dropzone" data-section="@secIndex" data-insert="@rowIndex"></div>
+                                        <div class="row g-3 mb-3 designer-row" data-section="@secIndex" data-row="@rowIndex" @key="sections[secIndex].Rows[rowIndex]">
+                                            @for (int i = 0; i < sections[secIndex].Rows[rowIndex].Fields.Count; i++)
+                                            {
+                                                <div class="col-12 col-md-@(12 / (sections[secIndex].Rows[rowIndex].Fields.Count == 0 ? 1 : sections[secIndex].Rows[rowIndex].Fields.Count))" data-id="@i" @key="sections[secIndex].Rows[rowIndex].Fields[i]">
+                                                    <FieldEditor Field="sections[secIndex].Rows[rowIndex].Fields[i]"
+                                                                 OnRemove="async f => await RemoveField(secIndex, rowIndex, f)"
+                                                                 OnDuplicate="async f => await DuplicateField(secIndex, rowIndex, f)" />
+                                                </div>
+                                            }
+                                            <div class="col-12 no-drop">
+                                                <button class="btn btn-sm btn-primary" @onclick="() => AddField(secIndex, rowIndex)">+ Add Column</button>
+                                            </div>
+                                        </div>
+                                    }
+                                    <div class="row-dropzone" data-section="@secIndex" data-insert="@sections[secIndex].Rows.Count"></div>
+                                    <div class="d-grid mb-3">
+                                        <button class="btn btn-primary" @onclick="() => AddRow(secIndex)">+ Add Row</button>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
                     </div>
                 }
-                <div class="row-dropzone" data-insert="@rows.Count"></div>
+                <div class="section-dropzone" data-insert="@sections.Count"></div>
                 <div class="d-grid mb-3">
-                    <button class="btn btn-primary" @onclick="AddRow">+ Add Row</button>
+                    <button class="btn btn-secondary" @onclick="AddSection">+ Add Section</button>
                 </div>
                 <div class="d-grid mb-2">
                     <button class="btn btn-primary btn-lg" @onclick="HandleSubmit">Create Form</button>
@@ -105,15 +177,24 @@
 }
 else
 {
-    <div class="card p-3 shadow-sm">
-        <LivePreview Rows="rows" FormName="@formName" />
+    <div class="row">
+        <div class="col-md-3" style="position:sticky;top:75px;max-height:calc(100vh - 90px);overflow-y:auto;">
+            <div class="mb-3">
+                <h5 class="mb-0">Toolbox</h5>
+            </div>
+        </div>
+        <div class="col-md-9">
+            <div class="card p-3 shadow-sm">
+                <LivePreview Sections="sections" FormName="@formName" />
+            </div>
+        </div>
     </div>
 }
 
 @code {
     private string formName = string.Empty;
     private string formDescription = string.Empty;
-    private List<DesignerRow> rows = new() { new DesignerRow() };
+    private List<DesignerSection> sections = new() { new DesignerSection() };
     private bool isPreviewMode = false;
     private bool requireLogin = true;
     private bool notifyOnResponse = false;
@@ -121,6 +202,39 @@ else
     private UserModel? currentUser;
     private DotNetObjectReference<Index>? objRef;
     private bool ignoreNavigationPrompt = false;
+    private List<string> deptOptions = new();
+    private List<string> locOptions = new();
+    private bool restrictionAlertShown = false;
+
+    private Stack<List<DesignerSection>> undoStack = new();
+    private Stack<List<DesignerSection>> redoStack = new();
+
+    List<DesignerSection> CloneSections(List<DesignerSection> src) =>
+        JsonSerializer.Deserialize<List<DesignerSection>>(JsonSerializer.Serialize(src)) ?? new();
+
+    void PushUndo()
+    {
+        undoStack.Push(CloneSections(sections));
+        redoStack.Clear();
+    }
+
+    void Undo()
+    {
+        if (undoStack.Count == 0) return;
+        redoStack.Push(CloneSections(sections));
+        sections = undoStack.Pop();
+        OnSectionRestrictionChanged();
+    }
+
+    void Redo()
+    {
+        if (redoStack.Count == 0) return;
+        undoStack.Push(CloneSections(sections));
+        sections = redoStack.Pop();
+        OnSectionRestrictionChanged();
+    }
+
+    void TogglePreview() => isPreviewMode = !isPreviewMode;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -136,25 +250,90 @@ else
 
             currentUser = await UserService.GetUserData(user);
             notificationEmail = currentUser?.Email ?? string.Empty;
+            deptOptions = await UserService.GetDepartments();
+            locOptions = await UserService.GetLocations();
             objRef ??= DotNetObjectReference.Create(this);
         }
 
         if (!isPreviewMode)
         {
             objRef ??= DotNetObjectReference.Create(this);
-            await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef);
-            await JS.InvokeVoidAsync("initFieldDragDrop", "#fields-container", objRef);
+            await JS.InvokeVoidAsync("initSectionSortable", "#sections-container", objRef);
+            for (int i = 0; i < sections.Count; i++)
+            {
+                await JS.InvokeVoidAsync("initSortable", $"#section-{i}-rows", objRef);
+            }
+            await JS.InvokeVoidAsync("initFieldDragDrop", "#sections-container", objRef);
         }
     }
 
-    [JSInvokable]
-    public void OnSortUpdate(int fromRow, int oldIndex, int toRow, int newIndex)
+    bool SectionsHaveRestrictions() => sections.Any(s => s.Departments.Any() || s.Locations.Any());
+
+    void OnSectionRestrictionChanged()
     {
-        if (fromRow < 0 || fromRow >= rows.Count || toRow < 0 || toRow >= rows.Count)
+        if (SectionsHaveRestrictions())
+        {
+            if (!requireLogin)
+                requireLogin = true;
+            if (!restrictionAlertShown)
+            {
+                NotificationService.Notify(new NotificationMessage
+                {
+                    Severity = NotificationSeverity.Warning,
+                    Summary = "Login required",
+                    Detail = "Section visibility filters require login to access the form."
+                });
+                restrictionAlertShown = true;
+            }
+        }
+        else
+        {
+            restrictionAlertShown = false;
+        }
+    }
+
+    void OnDepartmentsChanged(int secIndex, IEnumerable<string> values)
+    {
+        sections[secIndex].Departments = values.ToList();
+        OnSectionRestrictionChanged();
+    }
+
+    void OnLocationsChanged(int secIndex, IEnumerable<string> values)
+    {
+        sections[secIndex].Locations = values.ToList();
+        OnSectionRestrictionChanged();
+    }
+
+    void ToggleDepartmentFilter(int secIndex, ChangeEventArgs e)
+    {
+        sections[secIndex].UseDepartmentFilter = e.Value is bool b && b;
+        if (!sections[secIndex].UseDepartmentFilter)
+            sections[secIndex].Departments.Clear();
+        OnSectionRestrictionChanged();
+    }
+
+    void ToggleLocationFilter(int secIndex, ChangeEventArgs e)
+    {
+        sections[secIndex].UseLocationFilter = e.Value is bool b && b;
+        if (!sections[secIndex].UseLocationFilter)
+            sections[secIndex].Locations.Clear();
+        OnSectionRestrictionChanged();
+    }
+
+
+    [JSInvokable]
+    public void OnSortUpdate(int fromSection, int fromRow, int oldIndex, int toSection, int toRow, int newIndex)
+    {
+        if (fromSection < 0 || fromSection >= sections.Count || toSection < 0 || toSection >= sections.Count)
             return;
 
-        var source = rows[fromRow].Fields;
-        var dest = rows[toRow].Fields;
+        PushUndo();
+
+        if (fromRow < 0 || fromRow >= sections[fromSection].Rows.Count || toRow < 0 || toRow >= sections[toSection].Rows.Count)
+            return;
+
+        var source = sections[fromSection].Rows[fromRow].Fields;
+        var dest = sections[toSection].Rows[toRow].Fields;
 
         if (oldIndex < 0 || oldIndex >= source.Count || newIndex < 0 || newIndex > dest.Count)
             return;
@@ -177,23 +356,58 @@ else
         // clamp insert index to avoid out of range errors when moving within the same row
         int insertIndex = Math.Min(newIndex, dest.Count);
         dest.Insert(insertIndex, moved);
-        if (source.Count == 0 && rows.Count > 1)
+        if (source.Count == 0 && sections[fromSection].Rows.Count > 1)
         {
-            rows.RemoveAt(fromRow);
+            sections[fromSection].Rows.RemoveAt(fromRow);
         }
         StateHasChanged();
-        JS.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
+        JS.InvokeVoidAsync("initSortable", $"#section-{fromSection}-rows", objRef!);
+        if (fromSection != toSection)
+        {
+            JS.InvokeVoidAsync("initSortable", $"#section-{toSection}-rows", objRef!);
+        }
     }
 
-    async Task AddRow()
+    async Task AddRow(int section)
     {
-        rows.Add(new DesignerRow());
-        await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
+        PushUndo();
+        sections[section].Rows.Add(new DesignerRow());
+        await JS.InvokeVoidAsync("initSortable", $"#section-{section}-rows", objRef!);
     }
 
-    async Task AddField(int row)
+    async Task AddSection()
     {
-        if (rows[row].Fields.Count >= 4)
+        PushUndo();
+        sections.Add(new DesignerSection());
+        await JS.InvokeVoidAsync("initSectionSortable", "#sections-container", objRef!);
+        await JS.InvokeVoidAsync("initSortable", $"#section-{sections.Count - 1}-rows", objRef!);
+    }
+
+    DesignerField CreateField(string fieldType) => new DesignerField
+    {
+        FieldType = fieldType,
+        Key = fieldType switch
+        {
+            "user" => "select a user",
+            "department" => "department",
+            "location" => "location",
+            _ => string.Empty
+        },
+        Label = fieldType switch
+        {
+            "user" => "Select a user",
+            "department" => "Department",
+            "location" => "Location",
+            _ => string.Empty
+        },
+        Placeholder = fieldType == "text" ? "Short answer" :
+                      fieldType == "textarea" ? "Paragraph" :
+                      fieldType == "dropdown" ? "Select one from dropdown" : string.Empty
+    };
+
+    async Task AddField(int section, int row, string fieldType = "text")
+    {
+        if (sections[section].Rows[row].Fields.Count >= 4)
         {
             NotificationService.Notify(new NotificationMessage
             {
@@ -203,35 +417,43 @@ else
             });
             return;
         }
-        rows[row].Fields.Add(new DesignerField());
-        await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
+        PushUndo();
+        sections[section].Rows[row].Fields.Add(CreateField(fieldType));
+        await JS.InvokeVoidAsync("initSortable", $"#section-{section}-rows", objRef!);
+        await JS.InvokeVoidAsync("focusFieldLabel", section, row, sections[section].Rows[row].Fields.Count - 1);
     }
 
-    async Task RemoveField(int row, DesignerField field)
+    async Task RemoveField(int section, int row, DesignerField field)
     {
-        rows[row].Fields.Remove(field);
-        if (rows[row].Fields.Count == 0 && rows.Count > 1)
+        PushUndo();
+        sections[section].Rows[row].Fields.Remove(field);
+        if (sections[section].Rows[row].Fields.Count == 0 && sections[section].Rows.Count > 1)
         {
-            rows.RemoveAt(row);
+            sections[section].Rows.RemoveAt(row);
         }
-        await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
+        await JS.InvokeVoidAsync("initSortable", $"#section-{section}-rows", objRef!);
     }
 
-    async Task DuplicateField(int row, DesignerField field)
+    async Task DuplicateField(int section, int row, DesignerField field)
     {
+        PushUndo();
         var copy = new DesignerField
         {
-            Key = string.Empty,
+            Key = field.Key,
             Label = field.Label,
             FieldType = field.FieldType,
             IsRequired = field.IsRequired,
+            CharLimit = field.CharLimit,
+            MinCharLimit = field.MinCharLimit,
             OptionItems = new List<string>(field.OptionItems),
             GridColumns = new List<string>(field.GridColumns),
             GridRows = new List<string>(field.GridRows),
             ScaleMin = field.ScaleMin,
-            ScaleMax = field.ScaleMax
+            ScaleMax = field.ScaleMax,
+            Placeholder = field.Placeholder,
+            ImageUrl = field.ImageUrl
         };
-        var list = rows[row].Fields;
+        var list = sections[section].Rows[row].Fields;
         if (list.Count >= 4)
         {
             NotificationService.Notify(new NotificationMessage
@@ -244,17 +466,20 @@ else
         }
 
         list.Insert(list.IndexOf(field) + 1, copy);
-        await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
+        await JS.InvokeVoidAsync("initSortable", $"#section-{section}-rows", objRef!);
     }
 
     [JSInvokable]
-    public async Task AddFieldFromDrop(string fieldType, int rowIndex, int colIndex)
+    public async Task AddFieldFromDrop(string fieldType, int sectionIndex, int rowIndex, int colIndex)
     {
-        if (rowIndex < 0 || rowIndex >= rows.Count)
-            rowIndex = rows.Count - 1;
+        PushUndo();
+        if (sectionIndex < 0 || sectionIndex >= sections.Count)
+            sectionIndex = sections.Count - 1;
+        if (rowIndex < 0 || rowIndex >= sections[sectionIndex].Rows.Count)
+            rowIndex = sections[sectionIndex].Rows.Count - 1;
 
-        var list = rows[rowIndex].Fields;
-        var field = new DesignerField { FieldType = fieldType };
+        var list = sections[sectionIndex].Rows[rowIndex].Fields;
+        var field = CreateField(fieldType);
 
         if (list.Count >= 4)
         {
@@ -268,26 +493,124 @@ else
             return;
         }
 
+        int newIndex;
         if (colIndex < 0 || colIndex > list.Count)
+        {
             list.Add(field);
+            newIndex = list.Count - 1;
+        }
         else
+        {
             list.Insert(colIndex, field);
+            newIndex = colIndex;
+        }
 
         StateHasChanged();
-        await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
+        await JS.InvokeVoidAsync("initSortable", $"#section-{sectionIndex}-rows", objRef!);
+        await JS.InvokeVoidAsync("focusFieldLabel", sectionIndex, rowIndex, newIndex);
     }
 
     [JSInvokable]
-    public async Task AddRowFromDrop(string fieldType, int insertIndex)
+    public async Task AddRowFromDrop(string fieldType, int sectionIndex, int insertIndex)
     {
-        if (insertIndex < 0 || insertIndex > rows.Count)
-            insertIndex = rows.Count;
+        PushUndo();
+        if (sectionIndex < 0 || sectionIndex >= sections.Count)
+            sectionIndex = sections.Count - 1;
+        if (insertIndex < 0 || insertIndex > sections[sectionIndex].Rows.Count)
+            insertIndex = sections[sectionIndex].Rows.Count;
 
         var row = new DesignerRow();
-        row.Fields.Add(new DesignerField { FieldType = fieldType });
-        rows.Insert(insertIndex, row);
+        row.Fields.Add(CreateField(fieldType));
+        sections[sectionIndex].Rows.Insert(insertIndex, row);
         StateHasChanged();
-        await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
+        await JS.InvokeVoidAsync("initSortable", $"#section-{sectionIndex}-rows", objRef!);
+        await JS.InvokeVoidAsync("focusFieldLabel", sectionIndex, insertIndex, 0);
+    }
+
+    [JSInvokable]
+    public void OnSectionReorder(int oldIndex, int newIndex)
+    {
+        if (oldIndex == newIndex || oldIndex < 0 || newIndex < 0 || oldIndex >= sections.Count || newIndex >= sections.Count)
+            return;
+        PushUndo();
+        var item = sections[oldIndex];
+        sections.RemoveAt(oldIndex);
+        sections.Insert(newIndex, item);
+        StateHasChanged();
+    }
+
+    void ToggleCollapse(int index)
+    {
+        sections[index].IsCollapsed = !sections[index].IsCollapsed;
+    }
+
+    async Task DeleteSection(int index)
+    {
+        bool? confirm = await DialogService.Confirm(
+            "Delete this section and all its fields?",
+            "Delete Section",
+            new ConfirmOptions { OkButtonText = "Yes", CancelButtonText = "No" });
+        if (confirm == true)
+        {
+            PushUndo();
+            sections.RemoveAt(index);
+            await JS.InvokeVoidAsync("initSectionSortable", "#sections-container", objRef!);
+            OnSectionRestrictionChanged();
+        }
+    }
+
+    List<object> BuildFieldPayload()
+    {
+        var list = new List<object>();
+        int rowCounter = 0;
+        foreach (var sec in sections)
+        {
+            list.Add(new
+            {
+                Key = sec.Key,
+                Label = sec.Title,
+                FieldType = "section",
+                IsRequired = false,
+                Row = rowCounter,
+                Column = 0,
+                OptionsJson = (string.IsNullOrWhiteSpace(sec.Instructions) && sec.Departments.Count == 0 && sec.Locations.Count == 0)
+                    ? null
+                    : JsonSerializer.Serialize(new { Instructions = sec.Instructions, Departments = sec.Departments, Locations = sec.Locations })
+            });
+            rowCounter++;
+
+            foreach (var row in sec.Rows)
+            {
+                for (int c = 0; c < row.Fields.Count; c++)
+                {
+                    var f = row.Fields[c];
+                    var opts = f.OptionItems.Where(o => !string.IsNullOrWhiteSpace(o)).ToList();
+                    var rowsList = f.GridRows.Where(o => !string.IsNullOrWhiteSpace(o)).ToList();
+                    var colsList = f.GridColumns.Where(o => !string.IsNullOrWhiteSpace(o)).ToList();
+                    string? optionsJson = opts.Count > 0 ? JsonSerializer.Serialize(opts)
+                        : rowsList.Count > 0 || colsList.Count > 0 ? JsonSerializer.Serialize(new { Rows = rowsList, Columns = colsList })
+                        : f.FieldType == "scale" ? JsonSerializer.Serialize(new { Min = f.ScaleMin, Max = f.ScaleMax })
+                        : !string.IsNullOrWhiteSpace(f.Instructions) ? JsonSerializer.Serialize(new { Instructions = f.Instructions })
+                        : null;
+                    list.Add(new
+                    {
+                        f.Key,
+                        f.Label,
+                        f.FieldType,
+                        f.Placeholder,
+                        f.CharLimit,
+                        f.MinCharLimit,
+                        f.IsRequired,
+                        f.ImageUrl,
+                        Row = rowCounter,
+                        Column = c,
+                        OptionsJson = optionsJson
+                    });
+                }
+                rowCounter++;
+            }
+        }
+        return list;
     }
 
     async Task HandleSubmit()
@@ -303,9 +626,12 @@ else
             return;
         }
 
-        foreach (var f in rows.SelectMany(r => r.Fields))
+        if (SectionsHaveRestrictions())
+            requireLogin = true;
+
+        foreach (var f in sections.SelectMany(s => s.Rows).SelectMany(r => r.Fields))
         {
-            if (string.IsNullOrWhiteSpace(f.Label))
+            if (f.FieldType != "image" && string.IsNullOrWhiteSpace(f.Label))
             {
                 NotificationService.Notify(new NotificationMessage
                 {
@@ -316,13 +642,26 @@ else
                 return;
             }
 
-            if ((f.FieldType == "radio" || f.FieldType == "checkbox" || f.FieldType == "dropdown") && f.OptionItems.Count == 0)
+            if ((f.FieldType == "radio" || f.FieldType == "checkbox" || f.FieldType == "dropdown") &&
+                !f.OptionItems.Any(o => !string.IsNullOrWhiteSpace(o)))
             {
                 NotificationService.Notify(new NotificationMessage
                 {
                     Severity = NotificationSeverity.Warning,
-                    Summary = "Options required",
+                    Summary = "Options Required",
                     Detail = $"Add at least one option for '{f.Label}'."
+                });
+                return;
+            }
+
+            if ((f.FieldType == "grid_radio" || f.FieldType == "grid_checkbox") &&
+                (!f.GridRows.Any(r => !string.IsNullOrWhiteSpace(r)) || !f.GridColumns.Any(c => !string.IsNullOrWhiteSpace(c))))
+            {
+                NotificationService.Notify(new NotificationMessage
+                {
+                    Severity = NotificationSeverity.Warning,
+                    Summary = "Options Required",
+                    Detail = $"Add at least one row and column for '{f.Label}'."
                 });
                 return;
             }
@@ -336,19 +675,7 @@ else
             NotifyOnResponse = notifyOnResponse,
             NotificationEmail = string.IsNullOrWhiteSpace(notificationEmail) ? null : notificationEmail,
             IsActive = true,
-            Fields = rows.SelectMany((row, rIdx) => row.Fields.Select((f, cIdx) => new
-            {
-                f.Label,
-                f.FieldType,
-                f.IsRequired,
-                Row = rIdx,
-                Column = cIdx,
-                OptionsJson = JsonSerializer.Serialize(
-                    f.OptionItems.Count > 0 ? f.OptionItems :
-                    f.GridRows.Count > 0 || f.GridColumns.Count > 0 ? new { Rows = f.GridRows, Columns = f.GridColumns } :
-                    f.FieldType == "scale" ? new { Min = f.ScaleMin, Max = f.ScaleMax } : new object()
-                )
-            })).ToList()
+            Fields = BuildFieldPayload()
         };
 
         var resp = await Http.PostAsJsonAsync("api/forms", payload);
@@ -363,6 +690,9 @@ else
 
     private async Task SaveDraftAsync()
     {
+        if (SectionsHaveRestrictions())
+            requireLogin = true;
+
         var payload = new
         {
             Name = formName,
@@ -371,19 +701,7 @@ else
             NotifyOnResponse = notifyOnResponse,
             NotificationEmail = string.IsNullOrWhiteSpace(notificationEmail) ? null : notificationEmail,
             IsDraft = true,
-            Fields = rows.SelectMany((row, rIdx) => row.Fields.Select((f, cIdx) => new
-            {
-                f.Label,
-                f.FieldType,
-                f.IsRequired,
-                Row = rIdx,
-                Column = cIdx,
-                OptionsJson = JsonSerializer.Serialize(
-                    f.OptionItems.Count > 0 ? f.OptionItems :
-                    f.GridRows.Count > 0 || f.GridColumns.Count > 0 ? new { Rows = f.GridRows, Columns = f.GridColumns } :
-                    f.FieldType == "scale" ? new { Min = f.ScaleMin, Max = f.ScaleMax } : new object()
-                )
-            })).ToList()
+            Fields = BuildFieldPayload()
         };
 
         await Http.PostAsJsonAsync("api/forms", payload);
@@ -404,7 +722,7 @@ else
             return;
         }
 
-        if (rows.SelectMany(r => r.Fields).Count() >= 2)
+        if (sections.SelectMany(s => s.Rows).SelectMany(r => r.Fields).Count() >= 2)
         {
             context.PreventNavigation();
             bool? save = await DialogService.Confirm(

--- a/Client/Pages/DynamicForms/Index.razor
+++ b/Client/Pages/DynamicForms/Index.razor
@@ -147,15 +147,9 @@
                                                                  OnDuplicate="async f => await DuplicateField(secIndex, rowIndex, f)" />
                                                 </div>
                                             }
-                                            <div class="col-12 no-drop">
-                                                <button class="btn btn-sm btn-primary" @onclick="() => AddField(secIndex, rowIndex)">+ Add Column</button>
-                                            </div>
                                         </div>
                                     }
                                     <div class="row-dropzone" data-section="@secIndex" data-insert="@sections[secIndex].Rows.Count"></div>
-                                    <div class="d-grid mb-3">
-                                        <button class="btn btn-primary" @onclick="() => AddRow(secIndex)">+ Add Row</button>
-                                    </div>
                                 </div>
                             </div>
                         </div>
@@ -368,13 +362,6 @@ else
         }
     }
 
-    async Task AddRow(int section)
-    {
-        PushUndo();
-        sections[section].Rows.Add(new DesignerRow());
-        await JS.InvokeVoidAsync("initSortable", $"#section-{section}-rows", objRef!);
-    }
-
     async Task AddSection()
     {
         PushUndo();
@@ -404,24 +391,6 @@ else
                       fieldType == "textarea" ? "Paragraph" :
                       fieldType == "dropdown" ? "Select one from dropdown" : string.Empty
     };
-
-    async Task AddField(int section, int row, string fieldType = "text")
-    {
-        if (sections[section].Rows[row].Fields.Count >= 4)
-        {
-            NotificationService.Notify(new NotificationMessage
-            {
-                Severity = NotificationSeverity.Warning,
-                Summary = "Column limit reached",
-                Detail = "A row can contain at most four columns."
-            });
-            return;
-        }
-        PushUndo();
-        sections[section].Rows[row].Fields.Add(CreateField(fieldType));
-        await JS.InvokeVoidAsync("initSortable", $"#section-{section}-rows", objRef!);
-        await JS.InvokeVoidAsync("focusFieldLabel", section, row, sections[section].Rows[row].Fields.Count - 1);
-    }
 
     async Task RemoveField(int section, int row, DesignerField field)
     {

--- a/Client/Pages/DynamicForms/Index.razor
+++ b/Client/Pages/DynamicForms/Index.razor
@@ -451,7 +451,9 @@ else
             ScaleMin = field.ScaleMin,
             ScaleMax = field.ScaleMax,
             Placeholder = field.Placeholder,
-            ImageUrl = field.ImageUrl
+            ImageUrl = field.ImageUrl,
+            ImageWidth = field.ImageWidth,
+            ImageHeight = field.ImageHeight
         };
         var list = sections[section].Rows[row].Fields;
         if (list.Count >= 4)
@@ -602,6 +604,8 @@ else
                         f.MinCharLimit,
                         f.IsRequired,
                         f.ImageUrl,
+                        f.ImageWidth,
+                        f.ImageHeight,
                         Row = rowCounter,
                         Column = c,
                         OptionsJson = optionsJson

--- a/Client/Pages/DynamicForms/ViewResponse.razor
+++ b/Client/Pages/DynamicForms/ViewResponse.razor
@@ -215,6 +215,13 @@ else
                 builder.CloseElement();
             }
         }
+        else if (field.FieldType == "image")
+        {
+            if (!string.IsNullOrWhiteSpace(field.ImageUrl))
+            {
+                builder.AddMarkupContent(10, $"<img src='/{field.ImageUrl}' class='img-fluid' />");
+            }
+        }
         else if (field.FieldType == "checkbox")
         {
             if (!string.IsNullOrWhiteSpace(val))
@@ -264,6 +271,11 @@ else
             }
             return val;
         }
+        if (field.FieldType == "image")
+        {
+            return string.Empty;
+        }
+
         return val;
     }
 

--- a/Client/Pages/DynamicForms/ViewResponse.razor
+++ b/Client/Pages/DynamicForms/ViewResponse.razor
@@ -219,7 +219,8 @@ else
         {
             if (!string.IsNullOrWhiteSpace(field.ImageUrl))
             {
-                builder.AddMarkupContent(10, $"<img src='/{field.ImageUrl}' class='img-fluid' />");
+                var style = $"max-width:100%;{(field.ImageWidth.HasValue ? $"width:{field.ImageWidth}px;" : string.Empty)}{(field.ImageHeight.HasValue ? $"height:{field.ImageHeight}px;" : string.Empty)}";
+                builder.AddMarkupContent(10, $"<img src='/{field.ImageUrl}' style='{style}' />");
             }
         }
         else if (field.FieldType == "checkbox")

--- a/Client/Services/UserServiceProxy.cs
+++ b/Client/Services/UserServiceProxy.cs
@@ -1,6 +1,7 @@
 ﻿using DynamicFormsApp.Shared.Models;
 using DynamicFormsApp.Shared.Services;
 using System.Net.Http.Json;
+using System.Linq;
 
 namespace DynamicFormsApp.Client.Services
 {
@@ -33,6 +34,17 @@ namespace DynamicFormsApp.Client.Services
         {
             var encoded = System.Net.WebUtility.UrlEncode(term);
             return await _httpClient.GetFromJsonAsync<List<UserModel>>($"api/user/search?term={encoded}");
+        }
+
+        public async Task<List<string>> GetDepartments()
+        {
+            return await _httpClient.GetFromJsonAsync<List<string>>("api/user/departments");
+        }
+
+        public async Task<List<string>> GetLocations()
+        {
+            var list = await _httpClient.GetFromJsonAsync<List<string>>("api/user/locations");
+            return list.Where(l => !l.Contains("1511", StringComparison.OrdinalIgnoreCase) && !l.Contains("japan", StringComparison.OrdinalIgnoreCase)).ToList();
         }
     }
 }

--- a/NdaProcesses.Shared/DesignerField.cs
+++ b/NdaProcesses.Shared/DesignerField.cs
@@ -5,7 +5,13 @@
         public string Key { get; set; } = string.Empty;
         public string Label { get; set; } = string.Empty;
         public string FieldType { get; set; } = "text";
+        public string Instructions { get; set; } = string.Empty;
+        public string Placeholder { get; set; } = string.Empty;
+        public int? CharLimit { get; set; }
+        public int? MinCharLimit { get; set; }
         public bool IsRequired { get; set; }
+
+        public string ImageUrl { get; set; } = string.Empty;
 
         // Dynamic options
         public List<string> OptionItems { get; set; } = new();

--- a/NdaProcesses.Shared/DesignerField.cs
+++ b/NdaProcesses.Shared/DesignerField.cs
@@ -12,6 +12,8 @@
         public bool IsRequired { get; set; }
 
         public string ImageUrl { get; set; } = string.Empty;
+        public int? ImageWidth { get; set; }
+        public int? ImageHeight { get; set; }
 
         // Dynamic options
         public List<string> OptionItems { get; set; } = new();

--- a/NdaProcesses.Shared/DesignerSection.cs
+++ b/NdaProcesses.Shared/DesignerSection.cs
@@ -1,0 +1,15 @@
+namespace DynamicFormsApp.Shared
+{
+    public class DesignerSection
+    {
+        public string Key { get; set; } = string.Empty;
+        public string Title { get; set; } = string.Empty;
+        public string Instructions { get; set; } = string.Empty;
+        public bool IsCollapsed { get; set; }
+        public bool UseDepartmentFilter { get; set; }
+        public bool UseLocationFilter { get; set; }
+        public List<string> Departments { get; set; } = new();
+        public List<string> Locations { get; set; } = new();
+        public List<DesignerRow> Rows { get; set; } = new() { new DesignerRow() };
+    }
+}

--- a/NdaProcesses.Shared/Models/AppInfo.cs
+++ b/NdaProcesses.Shared/Models/AppInfo.cs
@@ -2,5 +2,5 @@ namespace DynamicFormsApp.Shared.Models;
 
 public static class AppInfo
 {
-    public const string Version = "0.9.1";
+public const string Version = "0.9.4";
 }

--- a/NdaProcesses.Shared/Models/AppInfo.cs
+++ b/NdaProcesses.Shared/Models/AppInfo.cs
@@ -2,5 +2,5 @@ namespace DynamicFormsApp.Shared.Models;
 
 public static class AppInfo
 {
-public const string Version = "0.9.5";
+public const string Version = "0.9.6";
 }

--- a/NdaProcesses.Shared/Models/AppInfo.cs
+++ b/NdaProcesses.Shared/Models/AppInfo.cs
@@ -2,5 +2,5 @@ namespace DynamicFormsApp.Shared.Models;
 
 public static class AppInfo
 {
-public const string Version = "0.9.4";
+public const string Version = "0.9.5";
 }

--- a/NdaProcesses.Shared/Models/AppInfo.cs
+++ b/NdaProcesses.Shared/Models/AppInfo.cs
@@ -2,5 +2,5 @@ namespace DynamicFormsApp.Shared.Models;
 
 public static class AppInfo
 {
-public const string Version = "0.9.6";
+public const string Version = "0.9.7";
 }

--- a/NdaProcesses.Shared/Models/CreateFieldDto.cs
+++ b/NdaProcesses.Shared/Models/CreateFieldDto.cs
@@ -13,5 +13,7 @@ namespace DynamicFormsApp.Shared.Models
         public int? Row { get; set; }
         public int? Column { get; set; }
         public string? ImageUrl { get; set; }
+        public int? ImageWidth { get; set; }
+        public int? ImageHeight { get; set; }
     }
 }

--- a/NdaProcesses.Shared/Models/CreateFieldDto.cs
+++ b/NdaProcesses.Shared/Models/CreateFieldDto.cs
@@ -5,9 +5,13 @@ namespace DynamicFormsApp.Shared.Models
         public string? Key { get; set; }
         public string Label { get; set; } = string.Empty;
         public string FieldType { get; set; } = "text";
+        public string? Placeholder { get; set; }
+        public int? CharLimit { get; set; }
+        public int? MinCharLimit { get; set; }
         public bool IsRequired { get; set; }
         public string? OptionsJson { get; set; }
         public int? Row { get; set; }
         public int? Column { get; set; }
+        public string? ImageUrl { get; set; }
     }
 }

--- a/NdaProcesses.Shared/Models/FormField.cs
+++ b/NdaProcesses.Shared/Models/FormField.cs
@@ -9,10 +9,15 @@ namespace DynamicFormsApp.Shared.Models
         public string Key { get; set; }      // SQL column name
         public string Label { get; set; }    // UI label
         public string FieldType { get; set; }// e.g., "text","number","dropdown", etc.
+        public string? Placeholder { get; set; }
+        public int? CharLimit { get; set; }
+        public int? MinCharLimit { get; set; }
         public bool IsRequired { get; set; }
 
         // Optional: for dropdowns, checkboxes, grids, etc.
         public string? OptionsJson { get; set; }
+
+        public string? ImageUrl { get; set; }
 
         // Optional: for layout (future grid fields support)
         public int? Row { get; set; }

--- a/NdaProcesses.Shared/Models/FormField.cs
+++ b/NdaProcesses.Shared/Models/FormField.cs
@@ -18,6 +18,8 @@ namespace DynamicFormsApp.Shared.Models
         public string? OptionsJson { get; set; }
 
         public string? ImageUrl { get; set; }
+        public int? ImageWidth { get; set; }
+        public int? ImageHeight { get; set; }
 
         // Optional: for layout (future grid fields support)
         public int? Row { get; set; }

--- a/NdaProcesses.Shared/Services/IUserService.cs
+++ b/NdaProcesses.Shared/Services/IUserService.cs
@@ -13,5 +13,7 @@ namespace DynamicFormsApp.Shared.Services
         Task<UserModel> GetUserData(string userName);
         Task<List<UserModel>> GetAllUsers();
         Task<List<UserModel>> SearchUsers(string term);
+        Task<List<string>> GetDepartments();
+        Task<List<string>> GetLocations();
     }
 }

--- a/Server/Components/App.razor
+++ b/Server/Components/App.razor
@@ -28,6 +28,7 @@
     <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
     <script src="js/sortable-wrapper.js?v=@AppInfo.Version"></script>
     <script src="js/dragdrop-wrapper.js?v=@AppInfo.Version"></script>
+    <script src="js/resize-image.js?v=@AppInfo.Version"></script>
     <script src="js/chartInterop.js?v=@AppInfo.Version"></script>
     <script type="module" src="js/exportHelper.js?v=@AppInfo.Version"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>

--- a/Server/Components/App.razor
+++ b/Server/Components/App.razor
@@ -24,12 +24,12 @@
     <script src="_framework/blazor.web.js?v=@AppInfo.Version"></script>
     <script src="_content/Radzen.Blazor/Radzen.Blazor.js?v=@(typeof(Radzen.Colors).Assembly.GetName().Version)&app=@AppInfo.Version"></script>
     <script>navigator.serviceWorker.register('service-worker.js?v=@AppInfo.Version');</script>
-    <script src="js/cookieHelper.js"></script>
+    <script src="js/cookieHelper.js?v=@AppInfo.Version"></script>
     <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
-    <script src="js/sortable-wrapper.js"></script>
-    <script src="js/dragdrop-wrapper.js"></script>
-    <script src="js/chartInterop.js"></script>
-    <script type="module" src="js/exportHelper.js"></script>
+    <script src="js/sortable-wrapper.js?v=@AppInfo.Version"></script>
+    <script src="js/dragdrop-wrapper.js?v=@AppInfo.Version"></script>
+    <script src="js/chartInterop.js?v=@AppInfo.Version"></script>
+    <script type="module" src="js/exportHelper.js?v=@AppInfo.Version"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>

--- a/Server/Controllers/UserController.cs
+++ b/Server/Controllers/UserController.cs
@@ -48,5 +48,19 @@ namespace DynamicFormsApp.Server.Controllers
             var users = await _userService.SearchUsers(term ?? string.Empty);
             return Ok(users);
         }
+
+        [HttpGet("departments")]
+        public async Task<ActionResult<IEnumerable<string>>> Departments()
+        {
+            var list = await _userService.GetDepartments();
+            return Ok(list);
+        }
+
+        [HttpGet("locations")]
+        public async Task<ActionResult<IEnumerable<string>>> Locations()
+        {
+            var list = await _userService.GetLocations();
+            return Ok(list);
+        }
     }
 }

--- a/Server/Services/DynamicFormService.cs
+++ b/Server/Services/DynamicFormService.cs
@@ -82,6 +82,8 @@ namespace DynamicFormsApp.Server.Services
                         IsRequired = f.IsRequired,
                         OptionsJson = f.OptionsJson,
                         ImageUrl = f.ImageUrl,
+                        ImageWidth = f.ImageWidth,
+                        ImageHeight = f.ImageHeight,
                         Row = f.Row,
                         Column = f.Column
                     }).ToList()
@@ -122,6 +124,8 @@ namespace DynamicFormsApp.Server.Services
                         IsRequired = fld.IsRequired,
                         OptionsJson = fld.OptionsJson,
                         ImageUrl = fld.ImageUrl,
+                        ImageWidth = fld.ImageWidth,
+                        ImageHeight = fld.ImageHeight,
                         Row = fld.Row,
                         Column = fld.Column
                     };
@@ -184,6 +188,8 @@ namespace DynamicFormsApp.Server.Services
                     match.IsRequired = fld.IsRequired;
                     match.OptionsJson = fld.OptionsJson;
                     match.ImageUrl = fld.ImageUrl;
+                    match.ImageWidth = fld.ImageWidth;
+                    match.ImageHeight = fld.ImageHeight;
                     match.Row = fld.Row;
                     match.Column = fld.Column;
                 }
@@ -202,6 +208,8 @@ namespace DynamicFormsApp.Server.Services
                         IsRequired = fld.IsRequired,
                         OptionsJson = fld.OptionsJson,
                         ImageUrl = fld.ImageUrl,
+                        ImageWidth = fld.ImageWidth,
+                        ImageHeight = fld.ImageHeight,
                         Row = fld.Row,
                         Column = fld.Column
                     };
@@ -254,6 +262,8 @@ namespace DynamicFormsApp.Server.Services
                     IsRequired = fld.IsRequired,
                     OptionsJson = fld.OptionsJson,
                     ImageUrl = fld.ImageUrl,
+                    ImageWidth = fld.ImageWidth,
+                    ImageHeight = fld.ImageHeight,
                     Row = fld.Row,
                     Column = fld.Column
                 });

--- a/Server/Services/DynamicFormService.cs
+++ b/Server/Services/DynamicFormService.cs
@@ -56,57 +56,58 @@ namespace DynamicFormsApp.Server.Services
                 .Where(f => !dto.Fields.Any(n => string.Equals(n.Key, f.Key, StringComparison.OrdinalIgnoreCase)))
                 .ToList();
 
-            if (deletions.Count > 0)
+            if (deletions.Count > 0 && !existing.IsDraft)
             {
-                if (!existing.IsDraft)
+                // Archive current form with a new ID and table
+                var archive = new Form
                 {
-                    // Deleting fields requires a new version with a fresh table
-                    existing.IsActive = false;
-                    await _db.SaveChangesAsync();
-
-                    var newId = await CreateFormAsync(dto.Name, dto.Description, dto.Fields, user,
-                        dto.RequireLogin, dto.NotifyOnResponse, dto.NotificationEmail, dto.IsActive,
-                        dto.IsDraft, existing.Version + 1, existing.Id);
-
-                    return newId;
-                }
-                else
-                {
-                    var rawName = SanitizeKey(existing.Name);
-                    var tableName = $"Form_{existing.Id}_{rawName}";
-                    foreach (var del in deletions)
+                    Name = existing.Name,
+                    Description = existing.Description,
+                    CreatedBy = existing.CreatedBy,
+                    RequireLogin = existing.RequireLogin,
+                    NotifyOnResponse = existing.NotifyOnResponse,
+                    NotificationEmail = existing.NotificationEmail,
+                    IsActive = false,
+                    IsDraft = existing.IsDraft,
+                    Version = existing.Version,
+                    PreviousVersionId = existing.PreviousVersionId,
+                    Fields = existing.Fields.Select(f => new FormField
                     {
-                        var sql = $"ALTER TABLE [{tableName}] DROP COLUMN [{del.Key}];";
-                        await _db.Database.ExecuteSqlRawAsync(sql);
-                        _db.FormFields.Remove(del);
-                    }
-                }
-            }
+                        Key = f.Key,
+                        Label = f.Label,
+                        FieldType = f.FieldType,
+                        Placeholder = f.Placeholder,
+                        CharLimit = f.CharLimit,
+                        MinCharLimit = f.MinCharLimit,
+                        IsRequired = f.IsRequired,
+                        OptionsJson = f.OptionsJson,
+                        ImageUrl = f.ImageUrl,
+                        Row = f.Row,
+                        Column = f.Column
+                    }).ToList()
+                };
 
-            // Update in place when no fields are removed
-            existing.Name = dto.Name;
-            existing.Description = dto.Description;
-            existing.RequireLogin = dto.RequireLogin;
-            existing.NotifyOnResponse = dto.NotifyOnResponse;
-            existing.NotificationEmail = dto.NotificationEmail;
-            existing.IsActive = dto.IsActive;
-            existing.IsDraft = dto.IsDraft;
+                _db.Forms.Add(archive);
+                await _db.SaveChangesAsync();
 
-            var keySet = new HashSet<string>(existing.Fields.Select(f => f.Key), StringComparer.OrdinalIgnoreCase);
+                var rawName = SanitizeKey(existing.Name);
+                var oldTable = $"Form_{existing.Id}_{rawName}";
+                var archiveTable = $"Form_{archive.Id}_{rawName}";
+                await _db.Database.ExecuteSqlRawAsync($"EXEC sp_rename '{oldTable}', '{archiveTable}'");
 
-            foreach (var fld in dto.Fields)
-            {
-                var match = existing.Fields.FirstOrDefault(f => f.Key.Equals(fld.Key, StringComparison.OrdinalIgnoreCase));
-                if (match != null)
+                // Prepare new table for the edited form
+                _db.FormFields.RemoveRange(existing.Fields);
+                existing.Fields.Clear();
+
+                var newTable = $"Form_{existing.Id}_{rawName}";
+                var sb = new StringBuilder($"CREATE TABLE [{newTable}] (ResponseId INT IDENTITY(1,1) PRIMARY KEY, CreatedAt DATETIME2 NOT NULL");
+                if (dto.RequireLogin)
                 {
-                    match.Label = fld.Label;
-                    match.FieldType = fld.FieldType;
-                    match.IsRequired = fld.IsRequired;
-                    match.OptionsJson = fld.OptionsJson;
-                    match.Row = fld.Row;
-                    match.Column = fld.Column;
+                    sb.Append(", [ResponderName] NVARCHAR(255) NULL");
                 }
-                else
+
+                var keySet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                foreach (var fld in dto.Fields)
                 {
                     var keySource = string.IsNullOrWhiteSpace(fld.Key) ? fld.Label : fld.Key;
                     var key = GetUniqueKey(keySource, keySet);
@@ -115,8 +116,92 @@ namespace DynamicFormsApp.Server.Services
                         Key = key,
                         Label = fld.Label,
                         FieldType = fld.FieldType,
+                        Placeholder = fld.Placeholder,
+                        CharLimit = fld.CharLimit,
+                        MinCharLimit = fld.MinCharLimit,
                         IsRequired = fld.IsRequired,
                         OptionsJson = fld.OptionsJson,
+                        ImageUrl = fld.ImageUrl,
+                        Row = fld.Row,
+                        Column = fld.Column
+                    };
+                    existing.Fields.Add(newField);
+
+                    if (newField.FieldType != "section" && newField.FieldType != "title" && newField.FieldType != "image")
+                    {
+                        sb.Append($", [{newField.Key}] {MapToSqlType(newField.FieldType)} {(newField.IsRequired ? "NOT NULL" : "NULL")}");
+                    }
+                }
+                sb.Append(");");
+                await _db.Database.ExecuteSqlRawAsync(sb.ToString());
+
+                existing.Version += 1;
+                existing.PreviousVersionId = archive.Id;
+                existing.Name = dto.Name;
+                existing.Description = dto.Description;
+                existing.RequireLogin = dto.RequireLogin;
+                existing.NotifyOnResponse = dto.NotifyOnResponse;
+                existing.NotificationEmail = dto.NotificationEmail;
+                existing.IsActive = dto.IsActive;
+                existing.IsDraft = dto.IsDraft;
+
+                await _db.SaveChangesAsync();
+                return existing.Id;
+            }
+
+            if (deletions.Count > 0)
+            {
+                var rawName = SanitizeKey(existing.Name);
+                var tableName = $"Form_{existing.Id}_{rawName}";
+                foreach (var del in deletions)
+                {
+                    var sql = $"ALTER TABLE [{tableName}] DROP COLUMN [{del.Key}];";
+                    await _db.Database.ExecuteSqlRawAsync(sql);
+                    _db.FormFields.Remove(del);
+                }
+            }
+
+            existing.Name = dto.Name;
+            existing.Description = dto.Description;
+            existing.RequireLogin = dto.RequireLogin;
+            existing.NotifyOnResponse = dto.NotifyOnResponse;
+            existing.NotificationEmail = dto.NotificationEmail;
+            existing.IsActive = dto.IsActive;
+            existing.IsDraft = dto.IsDraft;
+
+            var existingKeys = new HashSet<string>(existing.Fields.Select(f => f.Key), StringComparer.OrdinalIgnoreCase);
+
+            foreach (var fld in dto.Fields)
+            {
+                var match = existing.Fields.FirstOrDefault(f => f.Key.Equals(fld.Key, StringComparison.OrdinalIgnoreCase));
+                if (match != null)
+                {
+                    match.Label = fld.Label;
+                    match.FieldType = fld.FieldType;
+                    match.Placeholder = fld.Placeholder;
+                    match.CharLimit = fld.CharLimit;
+                    match.MinCharLimit = fld.MinCharLimit;
+                    match.IsRequired = fld.IsRequired;
+                    match.OptionsJson = fld.OptionsJson;
+                    match.ImageUrl = fld.ImageUrl;
+                    match.Row = fld.Row;
+                    match.Column = fld.Column;
+                }
+                else
+                {
+                    var keySource = string.IsNullOrWhiteSpace(fld.Key) ? fld.Label : fld.Key;
+                    var key = GetUniqueKey(keySource, existingKeys);
+                    var newField = new FormField
+                    {
+                        Key = key,
+                        Label = fld.Label,
+                        FieldType = fld.FieldType,
+                        Placeholder = fld.Placeholder,
+                        CharLimit = fld.CharLimit,
+                        MinCharLimit = fld.MinCharLimit,
+                        IsRequired = fld.IsRequired,
+                        OptionsJson = fld.OptionsJson,
+                        ImageUrl = fld.ImageUrl,
                         Row = fld.Row,
                         Column = fld.Column
                     };
@@ -124,11 +209,12 @@ namespace DynamicFormsApp.Server.Services
 
                     var rawName = SanitizeKey(existing.Name);
                     var tableName = $"Form_{existing.Id}_{rawName}";
-                    var sqlType = MapToSqlType(newField.FieldType);
-                    // Existing response rows may prevent adding a NOT NULL column.
-                    // Always allow nulls for new columns to avoid migration issues.
-                    var sql = $"ALTER TABLE [{tableName}] ADD [{newField.Key}] {sqlType} NULL;";
-                    await _db.Database.ExecuteSqlRawAsync(sql);
+                    if (newField.FieldType != "section" && newField.FieldType != "title" && newField.FieldType != "image")
+                    {
+                        var sqlType = MapToSqlType(newField.FieldType);
+                        var sql = $"ALTER TABLE [{tableName}] ADD [{newField.Key}] {sqlType} NULL;";
+                        await _db.Database.ExecuteSqlRawAsync(sql);
+                    }
                 }
             }
 
@@ -162,8 +248,12 @@ namespace DynamicFormsApp.Server.Services
                     Key = GetUniqueKey(keySource, keySet),
                     Label = fld.Label,
                     FieldType = fld.FieldType,
+                    Placeholder = fld.Placeholder,
+                    CharLimit = fld.CharLimit,
+                    MinCharLimit = fld.MinCharLimit,
                     IsRequired = fld.IsRequired,
                     OptionsJson = fld.OptionsJson,
+                    ImageUrl = fld.ImageUrl,
                     Row = fld.Row,
                     Column = fld.Column
                 });
@@ -184,6 +274,8 @@ namespace DynamicFormsApp.Server.Services
 
             foreach (var fld in form.Fields)
             {
+                if (fld.FieldType == "section" || fld.FieldType == "title" || fld.FieldType == "image")
+                    continue;
                 sb.Append($", [{fld.Key}] {MapToSqlType(fld.FieldType)} {(fld.IsRequired ? "NOT NULL" : "NULL")}");
             }
             sb.Append(");");
@@ -212,21 +304,22 @@ namespace DynamicFormsApp.Server.Services
             var rawName = SanitizeKey(form.Name);
             var tableName = $"Form_{formId}_{rawName}";
 
-            var cols = string.Join(", ", values.Keys.Select(k => $"[{k}]")) + ", CreatedAt";
-            var paramNames = string.Join(", ",
-                values.Keys.Select((k, i) => $"@p{i}")
-                           .Concat(new[] { "@p_created" }));
-            if (form.RequireLogin)
-            {
-                cols += ", ResponderName";
-                paramNames += ", @p_responder";
-            }
+            var validFields = form.Fields
+                .Where(f => f.FieldType != "section" && f.FieldType != "title" && f.FieldType != "image")
+                .Select(f => f.Key)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
-            var sql = $"INSERT INTO [{tableName}] ({cols}) VALUES ({paramNames});";
+            var filtered = values
+                .Where(kv => validFields.Contains(kv.Key))
+                .ToDictionary(k => k.Key, v => v.Value);
+
+            var cols = string.Join(", ", filtered.Keys.Select(k => $"[{k}]"));
+            var paramNames = string.Join(", ",
+                filtered.Keys.Select((k, i) => $"@p{i}"));
 
             var sqlParams = new List<SqlParameter>();
             int idx = 0;
-            foreach (var kv in values)
+            foreach (var kv in filtered)
             {
                 object raw = kv.Value;
                 if (raw is JsonElement je)
@@ -254,11 +347,18 @@ namespace DynamicFormsApp.Server.Services
                 idx++;
             }
 
+            cols = string.IsNullOrEmpty(cols) ? "CreatedAt" : cols + ", CreatedAt";
+            paramNames = string.IsNullOrEmpty(paramNames) ? "@p_created" : paramNames + ", @p_created";
             sqlParams.Add(new SqlParameter("@p_created", DateTime.UtcNow));
+
             if (form.RequireLogin)
             {
+                cols += ", ResponderName";
+                paramNames += ", @p_responder";
                 sqlParams.Add(new SqlParameter("@p_responder", (object?)responderName ?? DBNull.Value));
             }
+
+            var sql = $"INSERT INTO [{tableName}] ({cols}) VALUES ({paramNames});";
             await _db.Database.ExecuteSqlRawAsync(sql, sqlParams.ToArray());
 
             return form;
@@ -603,6 +703,9 @@ namespace DynamicFormsApp.Server.Services
             "file" => "NVARCHAR(MAX)",
             "checkbox" => "NVARCHAR(MAX)",      // Store as JSON array
             "dropdown" => "NVARCHAR(255)",
+            "user" => "NVARCHAR(255)",
+            "department" => "NVARCHAR(255)",
+            "location" => "NVARCHAR(255)",
             "radio" => "NVARCHAR(255)",
             "textarea" => "NVARCHAR(MAX)",
             "grid_radio" => "NVARCHAR(MAX)",    // JSON object

--- a/Server/Services/UserService.cs
+++ b/Server/Services/UserService.cs
@@ -1,5 +1,6 @@
 using DynamicFormsApp.Shared.Services;
 using DynamicFormsApp.Shared.Models;
+using System;
 using System.DirectoryServices;
 using System.Linq;
 
@@ -158,6 +159,74 @@ namespace DynamicFormsApp.Server.Services
             }
 
             return list.OrderBy(u => u.DisplayName).ToList();
+        }
+
+        public async Task<List<string>> GetDepartments()
+        {
+            var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            try
+            {
+                using var entry = new DirectoryEntry(
+                    _configuration["LDAP:LDAPPath"],
+                    _configuration["LDAP:UserName"],
+                    _configuration["LDAP:Password"],
+                    AuthenticationTypes.Secure);
+                using var searcher = new DirectorySearcher(entry)
+                {
+                    Filter = "(&(objectClass=user)(department=*))",
+                    PageSize = 1000
+                };
+                searcher.PropertiesToLoad.Add("department");
+                foreach (SearchResult result in searcher.FindAll())
+                {
+                    if (result.Properties["department"].Count == 0) continue;
+                    var dept = result.Properties["department"][0]?.ToString();
+                    if (!string.IsNullOrWhiteSpace(dept))
+                        set.Add(dept);
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error fetching departments: {ex.Message}");
+            }
+
+            return set.OrderBy(d => d).ToList();
+        }
+
+        public async Task<List<string>> GetLocations()
+        {
+            var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            try
+            {
+                using var entry = new DirectoryEntry(
+                    _configuration["LDAP:LDAPPath"],
+                    _configuration["LDAP:UserName"],
+                    _configuration["LDAP:Password"],
+                    AuthenticationTypes.Secure);
+                using var searcher = new DirectorySearcher(entry)
+                {
+                    Filter = "(&(objectClass=user)(physicalDeliveryOfficeName=*))",
+                    PageSize = 1000
+                };
+                searcher.PropertiesToLoad.Add("physicalDeliveryOfficeName");
+                foreach (SearchResult result in searcher.FindAll())
+                {
+                    if (result.Properties["physicalDeliveryOfficeName"].Count == 0) continue;
+                    var loc = result.Properties["physicalDeliveryOfficeName"][0]?.ToString();
+                    if (!string.IsNullOrWhiteSpace(loc)
+                        && !loc.Contains("1511", StringComparison.OrdinalIgnoreCase)
+                        && !loc.Contains("japan", StringComparison.OrdinalIgnoreCase))
+                    {
+                        set.Add(loc);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error fetching locations: {ex.Message}");
+            }
+
+            return set.OrderBy(l => l).ToList();
         }
 
         public async Task<List<UserModel>> SearchUsers(string term)

--- a/Server/wwwroot/css/form-builder.css
+++ b/Server/wwwroot/css/form-builder.css
@@ -79,6 +79,10 @@
     padding: 0 4px;
 }
 
+.section-filter-select {
+    min-width: 120px;
+}
+
 /* Dark mode overrides */
 body[data-bs-theme="dark"] {
     background-color: #212529;

--- a/Server/wwwroot/css/form-builder.css
+++ b/Server/wwwroot/css/form-builder.css
@@ -113,3 +113,17 @@ body[data-bs-theme="dark"] .designer-row::before {
     background: #343a40;
     color: #adb5bd;
 }
+.image-resize-wrapper {
+    position: relative;
+    display: inline-block;
+}
+.image-resize-wrapper .resize-handle {
+    width: 12px;
+    height: 12px;
+    background: #fff;
+    border: 1px solid #000;
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    cursor: se-resize;
+}

--- a/Server/wwwroot/js/dragdrop-wrapper.js
+++ b/Server/wwwroot/js/dragdrop-wrapper.js
@@ -29,24 +29,47 @@ window.initFieldDragDrop = (canvasSelector, dotnetHelper) => {
         const zone = e.target.closest('.row-dropzone');
         if (zone) {
             const insertIndex = parseInt(zone.getAttribute('data-insert'));
-            dotnetHelper.invokeMethodAsync('AddRowFromDrop', type, insertIndex);
+            const sec = parseInt(zone.getAttribute('data-section'));
+            dotnetHelper.invokeMethodAsync('AddRowFromDrop', type, sec, insertIndex);
             return;
         }
 
         const rowEl = e.target.closest('.designer-row');
         let rowIndex = -1;
+        let secIndex = -1;
         let colIndex = -1;
         if (rowEl) {
-            const rows = Array.from(canvas.querySelectorAll('.designer-row'));
-            rowIndex = rows.indexOf(rowEl);
+            const sectionEl = rowEl.closest('.section-wrapper');
+            if (sectionEl) secIndex = parseInt(sectionEl.getAttribute('data-section'));
+            rowIndex = parseInt(rowEl.getAttribute('data-row'));
             const colEl = e.target.closest('[data-id]');
             if (colEl) {
                 colIndex = parseInt(colEl.getAttribute('data-id'));
             }
         }
-        dotnetHelper.invokeMethodAsync('AddFieldFromDrop', type, rowIndex, colIndex);
+        dotnetHelper.invokeMethodAsync('AddFieldFromDrop', type, secIndex, rowIndex, colIndex);
     });
-}; 
+};
 
 // Backwards compatibility
 window.initDragDrop = window.initFieldDragDrop;
+
+window.focusFieldLabel = (sectionIndex, rowIndex, fieldIndex) => {
+    requestAnimationFrame(() => {
+        const selector = `#section-${sectionIndex}-rows .designer-row[data-row='${rowIndex}'] [data-id='${fieldIndex}'] input.form-control-sm`;
+        const el = document.querySelector(selector);
+        if (el) {
+            el.focus();
+        }
+    });
+};
+
+window.focusLastInput = (container) => {
+    if (!container) return;
+    requestAnimationFrame(() => {
+        const inputs = container.querySelectorAll('input');
+        if (inputs.length > 0) {
+            inputs[inputs.length - 1].focus();
+        }
+    });
+};

--- a/Server/wwwroot/js/dragdrop-wrapper.js
+++ b/Server/wwwroot/js/dragdrop-wrapper.js
@@ -73,3 +73,7 @@ window.focusLastInput = (container) => {
         }
     });
 };
+
+window.triggerClick = (el) => {
+    if (el) el.click();
+};

--- a/Server/wwwroot/js/resize-image.js
+++ b/Server/wwwroot/js/resize-image.js
@@ -22,6 +22,7 @@ window.initImageResize = (el, dotnetHelper) => {
     };
     handle.addEventListener('mousedown', e => {
         e.preventDefault();
+        e.stopPropagation();
         startX = e.clientX;
         startY = e.clientY;
         startW = img.offsetWidth;
@@ -29,4 +30,5 @@ window.initImageResize = (el, dotnetHelper) => {
         document.addEventListener('mousemove', onMouseMove);
         document.addEventListener('mouseup', onMouseUp);
     });
+    handle.addEventListener('click', e => e.stopPropagation());
 };

--- a/Server/wwwroot/js/resize-image.js
+++ b/Server/wwwroot/js/resize-image.js
@@ -1,0 +1,32 @@
+window.initImageResize = (el, dotnetHelper) => {
+    if (!el || el.dataset.resizeInit === 'true') return;
+    el.dataset.resizeInit = 'true';
+    const img = el.querySelector('img');
+    if (!img) return;
+    const handle = document.createElement('span');
+    handle.className = 'resize-handle';
+    el.appendChild(handle);
+    let startX, startY, startW, startH;
+    const onMouseMove = e => {
+        const newW = Math.max(20, startW + (e.clientX - startX));
+        const newH = Math.max(20, startH + (e.clientY - startY));
+        img.style.width = newW + 'px';
+        img.style.height = newH + 'px';
+    };
+    const onMouseUp = () => {
+        document.removeEventListener('mousemove', onMouseMove);
+        document.removeEventListener('mouseup', onMouseUp);
+        if (dotnetHelper) {
+            dotnetHelper.invokeMethodAsync('OnImageResized', img.offsetWidth, img.offsetHeight);
+        }
+    };
+    handle.addEventListener('mousedown', e => {
+        e.preventDefault();
+        startX = e.clientX;
+        startY = e.clientY;
+        startW = img.offsetWidth;
+        startH = img.offsetHeight;
+        document.addEventListener('mousemove', onMouseMove);
+        document.addEventListener('mouseup', onMouseUp);
+    });
+};

--- a/Server/wwwroot/js/sortable-wrapper.js
+++ b/Server/wwwroot/js/sortable-wrapper.js
@@ -19,9 +19,24 @@ window.initSortable = (selector, dotnetHelper) => {
             onEnd: function (evt) {
                 const fromRow = evt.from.getAttribute('data-row');
                 const toRow = evt.to.getAttribute('data-row');
-                dotnetHelper.invokeMethodAsync('OnSortUpdate', parseInt(fromRow), evt.oldIndex, parseInt(toRow), evt.newIndex);
+                const fromSection = evt.from.getAttribute('data-section');
+                const toSection = evt.to.getAttribute('data-section');
+                dotnetHelper.invokeMethodAsync('OnSortUpdate', parseInt(fromSection), parseInt(fromRow), evt.oldIndex, parseInt(toSection), parseInt(toRow), evt.newIndex);
             }
         });
+    });
+};
+
+window.initSectionSortable = (selector, dotnetHelper) => {
+    const container = document.querySelector(selector);
+    if (!container || container.dataset.sectionSortableInit === 'true') return;
+    container.dataset.sectionSortableInit = 'true';
+    new Sortable(container, {
+        animation: 150,
+        handle: '.section-drag-handle',
+        draggable: '.section-wrapper',
+        filter: '.section-dropzone, .section-dropzone *',
+        onEnd: evt => dotnetHelper.invokeMethodAsync('OnSectionReorder', evt.oldIndex, evt.newIndex)
     });
 };
 
@@ -33,5 +48,16 @@ window.initListSortable = (selector, dotnetHelper) => {
         animation: 150,
         handle: '.move-handle',
         onEnd: evt => dotnetHelper.invokeMethodAsync('OnFieldReorder', evt.oldIndex, evt.newIndex)
+    });
+};
+
+window.initValueSortable = (selector, dotnetHelper, callback) => {
+    const container = document.querySelector(selector);
+    if (!container || container.dataset.sortableInit === 'true') return;
+    container.dataset.sortableInit = 'true';
+    new Sortable(container, {
+        animation: 150,
+        handle: '.drag-handle',
+        onEnd: evt => dotnetHelper.invokeMethodAsync(callback, evt.oldIndex, evt.newIndex)
     });
 };


### PR DESCRIPTION
## Summary
- Allow users to interact with form fields inside the live preview
- Resolve breadcrumb IDs to form names by querying the form API
- Add floating undo/redo/preview toolbar with state history on form builder pages
- Keep builder controls beside the toolbox instead of floating
- Preserve form IDs when fields are deleted by archiving the previous version

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-8.0`
- `dotnet build DynamicFormsApp.sln`


------
https://chatgpt.com/codex/tasks/task_e_68837eeab99c832981bcf08cf5bfe70e