### PR TITLE
Support multi short answer fields

### DIFF
--- a/Client/Components/FieldEditor.razor
+++ b/Client/Components/FieldEditor.razor
@@ -36,7 +36,7 @@
             </div>
         }
 
-        @if (Field.FieldType is "radio" or "checkbox" or "dropdown")
+        @if (Field.FieldType is "radio" or "checkbox" or "dropdown" or "multi_text")
         {
             <label class="form-label mt-3">Options</label>
             <div @ref="optionsRef">
@@ -142,6 +142,7 @@
         "radio" => "Multiple Choice",
         "checkbox" => "Checkbox",
         "dropdown" => "Dropdown",
+        "multi_text" => "Multi Short Answer",
         "user" => "User Dropdown",
         "department" => "Department Dropdown",
         "location" => "Location Dropdown",

--- a/Client/Components/LivePreview.razor
+++ b/Client/Components/LivePreview.razor
@@ -64,9 +64,14 @@
                             </select>
                             break;
                         case "multi_text":
-                            @foreach (var opt in field.OptionItems)
+                            @for (int r = 0; r < 2; r++)
                             {
-                                <input class="form-control mb-2" placeholder="@(!string.IsNullOrWhiteSpace(opt) ? opt : "Short answer")" disabled />
+                                <div class="d-flex mb-2">
+                                    @foreach (var opt in field.OptionItems)
+                                    {
+                                        <input class="form-control me-1" placeholder="@(!string.IsNullOrWhiteSpace(opt) ? opt : "Short answer")" disabled />
+                                    }
+                                </div>
                             }
                             break;
                         case "user":

--- a/Client/Components/LivePreview.razor
+++ b/Client/Components/LivePreview.razor
@@ -63,6 +63,12 @@
                                 }
                             </select>
                             break;
+                        case "multi_text":
+                            @foreach (var opt in field.OptionItems)
+                            {
+                                <input class="form-control mb-2" placeholder="@(!string.IsNullOrWhiteSpace(opt) ? opt : "Short answer")" disabled />
+                            }
+                            break;
                         case "user":
                             <select class="form-select" disabled>
                                 <option>Select user</option>

--- a/Client/Pages/DynamicForms/EditFormPage.razor
+++ b/Client/Pages/DynamicForms/EditFormPage.razor
@@ -34,6 +34,7 @@ else if (!string.IsNullOrEmpty(deletedMessage))
             </div>
             <div class="d-flex flex-wrap gap-2">
                 <div class="draggable-field" draggable="true" data-type="text"><span class="material-icons me-1">short_text</span> Short Answer</div>
+                <div class="draggable-field" draggable="true" data-type="multi_text"><span class="material-icons me-1">view_list</span> Multi Short Answer</div>
                 <div class="draggable-field" draggable="true" data-type="textarea"><span class="material-icons me-1">notes</span> Paragraph</div>
                 <div class="draggable-field" draggable="true" data-type="radio"><span class="material-icons me-1">radio_button_checked</span> Multiple Choice</div>
                 <div class="draggable-field" draggable="true" data-type="checkbox"><span class="material-icons me-1">check_box</span> Checkbox</div>
@@ -722,7 +723,7 @@ List<object> BuildFieldPayload()
                 return;
             }
 
-            if ((f.FieldType == "radio" || f.FieldType == "checkbox" || f.FieldType == "dropdown") &&
+            if ((f.FieldType == "radio" || f.FieldType == "checkbox" || f.FieldType == "dropdown" || f.FieldType == "multi_text") &&
                 !f.OptionItems.Any(o => !string.IsNullOrWhiteSpace(o)))
             {
                 NotificationService.Notify(new NotificationMessage

--- a/Client/Pages/DynamicForms/FormDesigner.razor
+++ b/Client/Pages/DynamicForms/FormDesigner.razor
@@ -71,6 +71,7 @@
                 <div class="col-md-4">
                     <select class="form-select" @bind="field.FieldType">
                         <option value="text">Short Answer</option>
+                        <option value="multi_text">Multi Short Answer</option>
                         <option value="textarea">Paragraph</option>
                         <option value="radio">Multiple Choice</option>
                         <option value="checkbox">Checkbox</option>
@@ -221,7 +222,7 @@
                 return;
             }
 
-            if ((f.FieldType == "radio" || f.FieldType == "checkbox" || f.FieldType == "dropdown") &&
+            if ((f.FieldType == "radio" || f.FieldType == "checkbox" || f.FieldType == "dropdown" || f.FieldType == "multi_text") &&
                 f.Options.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).Length == 0)
             {
                 NotificationService.Notify(new NotificationMessage

--- a/Client/Pages/DynamicForms/FormRenderer.razor
+++ b/Client/Pages/DynamicForms/FormRenderer.razor
@@ -113,8 +113,8 @@ else
                                     <input type="text" class="form-control me-1"
                                            placeholder="@mtOptions[colIdx]"
                                            value="@mtRows[rowIdx][colIdx]"
-                                           @onchange="e => OnMultiTextChanged(fld.Key, rowIdx, colIdx, e, mtOptions.Count)" />
-                                }
+                                           @oninput="e => OnMultiTextChanged(fld.Key, rowIdx, colIdx, e, mtOptions.Count)" />
+                                    }
                                 @if (mtRows.Count > 1 && rowIdx < mtRows.Count - 1)
                                 {
                                     <button type="button" class="btn btn-outline-danger btn-sm"

--- a/Client/Pages/DynamicForms/FormRenderer.razor
+++ b/Client/Pages/DynamicForms/FormRenderer.razor
@@ -341,13 +341,24 @@ else
             rows = new List<List<string>>();
             responseData[key] = rows;
         }
-        EnsureBlankRow(rows, columns);
+        if (rows.Count == 0)
+            rows.Add(Enumerable.Repeat(string.Empty, columns).ToList());
+        EnsureSingleBlankRow(rows, columns);
         return rows;
     }
 
-    void EnsureBlankRow(List<List<string>> rows, int columns)
+    void EnsureSingleBlankRow(List<List<string>> rows, int columns)
     {
-        if (rows.Count == 0 || rows[^1].Any(v => !string.IsNullOrWhiteSpace(v)))
+        if (rows.Count == 0)
+        {
+            rows.Add(Enumerable.Repeat(string.Empty, columns).ToList());
+            return;
+        }
+
+        while (rows.Count > 1 && rows[^1].All(string.IsNullOrWhiteSpace) && rows[^2].All(string.IsNullOrWhiteSpace))
+            rows.RemoveAt(rows.Count - 1);
+
+        if (rows[^1].Any(v => !string.IsNullOrWhiteSpace(v)))
             rows.Add(Enumerable.Repeat(string.Empty, columns).ToList());
     }
 
@@ -454,7 +465,8 @@ else
         while (row.Count <= colIdx)
             row.Add(string.Empty);
         row[colIdx] = e.Value?.ToString() ?? string.Empty;
-        EnsureBlankRow(rows, columns);
+
+        EnsureSingleBlankRow(rows, columns);
     }
 
     void RemoveMultiTextRow(string key, int rowIdx, int columns)
@@ -463,7 +475,7 @@ else
             return;
         if (rowIdx < rows.Count)
             rows.RemoveAt(rowIdx);
-        EnsureBlankRow(rows, columns);
+        EnsureSingleBlankRow(rows, columns);
     }
 
     void OnCheckboxChanged(string key, string option, ChangeEventArgs e)

--- a/Client/Pages/DynamicForms/FormRenderer.razor
+++ b/Client/Pages/DynamicForms/FormRenderer.razor
@@ -102,14 +102,25 @@ else
                         </select>
                         break;
                     case "multi_text":
-                        var mtOptions = JsonSerializer.Deserialize<List<string>>(fld.OptionsJson ?? "[]");
-                        for (int idx = 0; idx < mtOptions.Count; idx++)
+                        var mtOptions = JsonSerializer.Deserialize<List<string>>(fld.OptionsJson ?? "[]") ?? new();
+        
+                        var mtRows = GetMultiTextRows(fld.Key, mtOptions.Count);
+                        for (int rowIdx = 0; rowIdx < mtRows.Count; rowIdx++)
                         {
-                            var ph = mtOptions[idx];
-                            <input type="text" class="form-control mb-2"
-                                   placeholder="@ph"
-                                   value="@GetMultiTextValue(fld.Key, idx)"
-                                   @onchange="e => OnMultiTextChanged(fld.Key, idx, e)" />
+                            <div class="d-flex mb-2">
+                                @for (int colIdx = 0; colIdx < mtOptions.Count; colIdx++)
+                                {
+                                    <input type="text" class="form-control me-1"
+                                           placeholder="@mtOptions[colIdx]"
+                                           value="@mtRows[rowIdx][colIdx]"
+                                           @onchange="e => OnMultiTextChanged(fld.Key, rowIdx, colIdx, e, mtOptions.Count)" />
+                                }
+                                @if (mtRows.Count > 1 && rowIdx < mtRows.Count - 1)
+                                {
+                                    <button type="button" class="btn btn-outline-danger btn-sm"
+                                            @onclick="() => RemoveMultiTextRow(fld.Key, rowIdx, mtOptions.Count)">x</button>
+                                }
+                            </div>
                         }
                         break;
 
@@ -294,7 +305,10 @@ else
                 if (fld.FieldType == "multi_text")
                 {
                     var opts = JsonSerializer.Deserialize<List<string>>(fld.OptionsJson ?? "[]") ?? new();
-                    responseData[fld.Key] = Enumerable.Repeat(string.Empty, opts.Count).ToList();
+                    responseData[fld.Key] = new List<List<string>>
+                    {
+                        Enumerable.Repeat(string.Empty, opts.Count).ToList()
+                    };
                 }
                 else
                 {
@@ -320,11 +334,21 @@ else
     string GetDateString(string key) => responseData[key] is DateTime dt ? dt.ToString("yyyy-MM-dd") : "";
     string GetTimeString(string key) => responseData[key] is TimeSpan ts ? ts.ToString(@"hh\:mm") : "";
     string GetDateTimeString(string key) => responseData[key] is DateTime dt ? dt.ToString("yyyy-MM-ddTHH:mm") : "";
-    string GetMultiTextValue(string key, int index)
+    List<List<string>> GetMultiTextRows(string key, int columns)
     {
-        if (responseData.TryGetValue(key, out var obj) && obj is List<string> list && index < list.Count)
-            return list[index];
-        return string.Empty;
+        if (!responseData.TryGetValue(key, out var obj) || obj is not List<List<string>> rows)
+        {
+            rows = new List<List<string>>();
+            responseData[key] = rows;
+        }
+        EnsureBlankRow(rows, columns);
+        return rows;
+    }
+
+    void EnsureBlankRow(List<List<string>> rows, int columns)
+    {
+        if (rows.Count == 0 || rows[^1].Any(v => !string.IsNullOrWhiteSpace(v)))
+            rows.Add(Enumerable.Repeat(string.Empty, columns).ToList());
     }
 
     string? GetInstructions(FormField field)
@@ -421,16 +445,25 @@ else
             responseData[key] = null;
     }
 
-    void OnMultiTextChanged(string key, int index, ChangeEventArgs e)
+    void OnMultiTextChanged(string key, int rowIdx, int colIdx, ChangeEventArgs e, int columns)
     {
-        if (!responseData.TryGetValue(key, out var existing) || existing is not List<string> list)
-        {
-            list = new List<string>();
-            responseData[key] = list;
-        }
-        while (list.Count <= index)
-            list.Add(string.Empty);
-        list[index] = e.Value?.ToString() ?? string.Empty;
+        var rows = GetMultiTextRows(key, columns);
+        while (rows.Count <= rowIdx)
+            rows.Add(Enumerable.Repeat(string.Empty, columns).ToList());
+        var row = rows[rowIdx];
+        while (row.Count <= colIdx)
+            row.Add(string.Empty);
+        row[colIdx] = e.Value?.ToString() ?? string.Empty;
+        EnsureBlankRow(rows, columns);
+    }
+
+    void RemoveMultiTextRow(string key, int rowIdx, int columns)
+    {
+        if (!responseData.TryGetValue(key, out var obj) || obj is not List<List<string>> rows)
+            return;
+        if (rowIdx < rows.Count)
+            rows.RemoveAt(rowIdx);
+        EnsureBlankRow(rows, columns);
     }
 
     void OnCheckboxChanged(string key, string option, ChangeEventArgs e)
@@ -528,6 +561,16 @@ else
                     f.FieldType != "title"))
             .ToDictionary(k => k.Key, v => v.Value);
 
+        foreach (var key in submitData.Keys.ToList())
+        {
+            if (submitData[key] is List<List<string>> rows)
+            {
+                submitData[key] = rows
+                    .Where(r => r.Any(c => !string.IsNullOrWhiteSpace(c)))
+                    .ToList();
+            }
+        }
+
         await Http.PostAsJsonAsync($"api/forms/{FormId}/responses", submitData);
 
         var user = await CookieHelper.LoginStatus();
@@ -546,6 +589,8 @@ else
         if (value == null) return true;
         if (value is string s) return string.IsNullOrWhiteSpace(s);
         if (value is IEnumerable<string> list) return !list.Any(v => !string.IsNullOrWhiteSpace(v));
+        if (value is IEnumerable<IEnumerable<string>> matrix)
+            return !matrix.Any(r => r.Any(c => !string.IsNullOrWhiteSpace(c)));
         return false;
     }
 

--- a/Client/Pages/DynamicForms/FormRenderer.razor
+++ b/Client/Pages/DynamicForms/FormRenderer.razor
@@ -101,6 +101,17 @@ else
                             }
                         </select>
                         break;
+                    case "multi_text":
+                        var mtOptions = JsonSerializer.Deserialize<List<string>>(fld.OptionsJson ?? "[]");
+                        for (int idx = 0; idx < mtOptions.Count; idx++)
+                        {
+                            var ph = mtOptions[idx];
+                            <input type="text" class="form-control mb-2"
+                                   placeholder="@ph"
+                                   value="@GetMultiTextValue(fld.Key, idx)"
+                                   @onchange="e => OnMultiTextChanged(fld.Key, idx, e)" />
+                        }
+                        break;
 
                     case "user":
                         <select class="form-select" value="@GetString(fld.Key)" @onchange="e => OnTextChanged(fld.Key, e)">
@@ -280,16 +291,24 @@ else
                     continue;
                 }
 
-                responseData[fld.Key] = fld.FieldType switch
+                if (fld.FieldType == "multi_text")
                 {
-                    "checkbox" => new List<string>(),
-                    "number" => (object?)null,
-                    "date" => (object?)null,
-                    "time" => (object?)null,
-                    "datetime" => (object?)null,
-                    "file" => "",
-                    _ => string.Empty
-                };
+                    var opts = JsonSerializer.Deserialize<List<string>>(fld.OptionsJson ?? "[]") ?? new();
+                    responseData[fld.Key] = Enumerable.Repeat(string.Empty, opts.Count).ToList();
+                }
+                else
+                {
+                    responseData[fld.Key] = fld.FieldType switch
+                    {
+                        "checkbox" => new List<string>(),
+                        "number" => (object?)null,
+                        "date" => (object?)null,
+                        "time" => (object?)null,
+                        "datetime" => (object?)null,
+                        "file" => "",
+                        _ => string.Empty
+                    };
+                }
             }
 
             StateHasChanged();
@@ -301,6 +320,12 @@ else
     string GetDateString(string key) => responseData[key] is DateTime dt ? dt.ToString("yyyy-MM-dd") : "";
     string GetTimeString(string key) => responseData[key] is TimeSpan ts ? ts.ToString(@"hh\:mm") : "";
     string GetDateTimeString(string key) => responseData[key] is DateTime dt ? dt.ToString("yyyy-MM-ddTHH:mm") : "";
+    string GetMultiTextValue(string key, int index)
+    {
+        if (responseData.TryGetValue(key, out var obj) && obj is List<string> list && index < list.Count)
+            return list[index];
+        return string.Empty;
+    }
 
     string? GetInstructions(FormField field)
     {
@@ -394,6 +419,18 @@ else
             responseData[key] = dt;
         else
             responseData[key] = null;
+    }
+
+    void OnMultiTextChanged(string key, int index, ChangeEventArgs e)
+    {
+        if (!responseData.TryGetValue(key, out var existing) || existing is not List<string> list)
+        {
+            list = new List<string>();
+            responseData[key] = list;
+        }
+        while (list.Count <= index)
+            list.Add(string.Empty);
+        list[index] = e.Value?.ToString() ?? string.Empty;
     }
 
     void OnCheckboxChanged(string key, string option, ChangeEventArgs e)
@@ -508,7 +545,7 @@ else
     {
         if (value == null) return true;
         if (value is string s) return string.IsNullOrWhiteSpace(s);
-        if (value is IEnumerable<string> list) return !list.Any();
+        if (value is IEnumerable<string> list) return !list.Any(v => !string.IsNullOrWhiteSpace(v));
         return false;
     }
 

--- a/Client/Pages/DynamicForms/FormSummary.razor
+++ b/Client/Pages/DynamicForms/FormSummary.razor
@@ -139,12 +139,33 @@ else
         {
             if (val is JsonElement je && je.ValueKind == JsonValueKind.Array)
             {
+                if (field.FieldType == "multi_text")
+                    return je.EnumerateArray().SelectMany(r => r.EnumerateArray().Select(e => e.GetString())
+                        .Where(v => !string.IsNullOrWhiteSpace(v)));
                 return je.EnumerateArray().Select(e => e.GetString()).Where(v => !string.IsNullOrWhiteSpace(v));
+            }
+            else if (val is string s)
+            {
+                try
+                {
+                    using var doc = JsonDocument.Parse(s);
+                    if (doc.RootElement.ValueKind == JsonValueKind.Array)
+                    {
+                        if (field.FieldType == "multi_text")
+                            return doc.RootElement.EnumerateArray()
+                                .SelectMany(r => r.EnumerateArray().Select(e => e.GetString())
+                                .Where(v => !string.IsNullOrWhiteSpace(v)));
+                        return doc.RootElement.EnumerateArray()
+                            .Select(e => e.GetString()).Where(v => !string.IsNullOrWhiteSpace(v));
+                    }
+                }
+                catch { }
             }
             else if (val is IEnumerable<string> strList)
             {
                 return strList;
             }
+            return Enumerable.Empty<string>();
         }
 
         return new[] { val.ToString() };

--- a/Client/Pages/DynamicForms/FormSummary.razor
+++ b/Client/Pages/DynamicForms/FormSummary.razor
@@ -45,7 +45,7 @@ else
                     <p>No numeric data.</p>
                 }
             }
-            else if (field.FieldType is "dropdown" or "radio" or "checkbox")
+            else if (field.FieldType is "dropdown" or "radio" or "checkbox" or "multi_text")
             {
                 var allValues = responses.SelectMany(r => ExtractOptions(r, field)).ToList();
                 var grouped = allValues.GroupBy(v => v).ToDictionary(g => g.Key, g => g.Count());
@@ -135,7 +135,7 @@ else
         if (!row.TryGetValue(field.Key, out var val) || val is null)
             return Enumerable.Empty<string>();
 
-        if (field.FieldType == "checkbox")
+        if (field.FieldType == "checkbox" || field.FieldType == "multi_text")
         {
             if (val is JsonElement je && je.ValueKind == JsonValueKind.Array)
             {

--- a/Client/Pages/DynamicForms/Index.razor
+++ b/Client/Pages/DynamicForms/Index.razor
@@ -27,6 +27,7 @@
             </div>
             <div class="d-flex flex-wrap gap-2">
                 <div class="draggable-field" draggable="true" data-type="text"><span class="material-icons me-1">short_text</span> Short Answer</div>
+                <div class="draggable-field" draggable="true" data-type="multi_text"><span class="material-icons me-1">view_list</span> Multi Short Answer</div>
                 <div class="draggable-field" draggable="true" data-type="textarea"><span class="material-icons me-1">notes</span> Paragraph</div>
                 <div class="draggable-field" draggable="true" data-type="radio"><span class="material-icons me-1">radio_button_checked</span> Multiple Choice</div>
                 <div class="draggable-field" draggable="true" data-type="checkbox"><span class="material-icons me-1">check_box</span> Checkbox</div>
@@ -585,7 +586,7 @@ else
                 return;
             }
 
-            if ((f.FieldType == "radio" || f.FieldType == "checkbox" || f.FieldType == "dropdown") &&
+            if ((f.FieldType == "radio" || f.FieldType == "checkbox" || f.FieldType == "dropdown" || f.FieldType == "multi_text") &&
                 !f.OptionItems.Any(o => !string.IsNullOrWhiteSpace(o)))
             {
                 NotificationService.Notify(new NotificationMessage

--- a/Client/Pages/DynamicForms/ViewResponse.razor
+++ b/Client/Pages/DynamicForms/ViewResponse.razor
@@ -215,7 +215,7 @@ else
                 builder.CloseElement();
             }
         }
-        else if (field.FieldType == "checkbox" || field.FieldType == "multi_text")
+        else if (field.FieldType == "checkbox")
         {
             if (!string.IsNullOrWhiteSpace(val))
             {
@@ -223,6 +223,24 @@ else
                 {
                     var list = JsonSerializer.Deserialize<List<string>>(val) ?? new();
                     builder.AddContent(7, string.Join(", ", list));
+                }
+                catch
+                {
+                    builder.AddContent(8, val);
+                }
+            }
+        }
+        else if (field.FieldType == "multi_text")
+        {
+            if (!string.IsNullOrWhiteSpace(val))
+            {
+                try
+                {
+                    var rows = JsonSerializer.Deserialize<List<List<string>>>(val) ?? new();
+                    var formatted = rows
+                        .Where(r => r.Any(c => !string.IsNullOrWhiteSpace(c)))
+                        .Select(r => string.Join(", ", r.Where(c => !string.IsNullOrWhiteSpace(c))));
+                    builder.AddContent(7, string.Join("; ", formatted));
                 }
                 catch
                 {
@@ -249,7 +267,7 @@ else
         if (response == null) return string.Empty;
         response.TryGetValue(field.Key, out var valObj);
         var val = valObj?.ToString() ?? string.Empty;
-        if (field.FieldType == "checkbox" || field.FieldType == "multi_text")
+        if (field.FieldType == "checkbox")
         {
             if (!string.IsNullOrWhiteSpace(val))
             {
@@ -258,9 +276,23 @@ else
                     var list = JsonSerializer.Deserialize<List<string>>(val) ?? new();
                     return string.Join(", ", list);
                 }
-                catch
+                catch { }
+            }
+            return val;
+        }
+        else if (field.FieldType == "multi_text")
+        {
+            if (!string.IsNullOrWhiteSpace(val))
+            {
+                try
                 {
+                    var rows = JsonSerializer.Deserialize<List<List<string>>>(val) ?? new();
+                    var formatted = rows
+                        .Where(r => r.Any(c => !string.IsNullOrWhiteSpace(c)))
+                        .Select(r => string.Join(", ", r.Where(c => !string.IsNullOrWhiteSpace(c))));
+                    return string.Join("; ", formatted);
                 }
+                catch { }
             }
             return val;
         }

--- a/Client/Pages/DynamicForms/ViewResponse.razor
+++ b/Client/Pages/DynamicForms/ViewResponse.razor
@@ -215,7 +215,7 @@ else
                 builder.CloseElement();
             }
         }
-        else if (field.FieldType == "checkbox")
+        else if (field.FieldType == "checkbox" || field.FieldType == "multi_text")
         {
             if (!string.IsNullOrWhiteSpace(val))
             {
@@ -249,7 +249,7 @@ else
         if (response == null) return string.Empty;
         response.TryGetValue(field.Key, out var valObj);
         var val = valObj?.ToString() ?? string.Empty;
-        if (field.FieldType == "checkbox")
+        if (field.FieldType == "checkbox" || field.FieldType == "multi_text")
         {
             if (!string.IsNullOrWhiteSpace(val))
             {

--- a/Server/Services/DynamicFormService.cs
+++ b/Server/Services/DynamicFormService.cs
@@ -264,6 +264,10 @@ namespace DynamicFormsApp.Server.Services
                 {
                     raw = JsonSerializer.Serialize(stringList);
                 }
+                else if (raw is List<List<string>> listList)
+                {
+                    raw = JsonSerializer.Serialize(listList);
+                }
 
                 sqlParams.Add(new SqlParameter($"@p{idx}", raw ?? DBNull.Value));
                 idx++;
@@ -624,7 +628,7 @@ namespace DynamicFormsApp.Server.Services
             "datetime" => "DATETIME2",
             "file" => "NVARCHAR(MAX)",
             "checkbox" => "NVARCHAR(MAX)",      // Store as JSON array
-            "multi_text" => "NVARCHAR(MAX)",   // JSON array of strings
+            "multi_text" => "NVARCHAR(MAX)",   // JSON array of arrays of strings
             "dropdown" => "NVARCHAR(255)",
             "user" => "NVARCHAR(255)",
             "department" => "NVARCHAR(255)",

--- a/Server/Services/DynamicFormService.cs
+++ b/Server/Services/DynamicFormService.cs
@@ -624,6 +624,7 @@ namespace DynamicFormsApp.Server.Services
             "datetime" => "DATETIME2",
             "file" => "NVARCHAR(MAX)",
             "checkbox" => "NVARCHAR(MAX)",      // Store as JSON array
+            "multi_text" => "NVARCHAR(MAX)",   // JSON array of strings
             "dropdown" => "NVARCHAR(255)",
             "user" => "NVARCHAR(255)",
             "department" => "NVARCHAR(255)",


### PR DESCRIPTION
## Summary
- Add `multi_text` field type with editable options and labels
- Render and store multi text responses as string arrays
- Display multi text answers in summaries and individual responses

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68a5f1c9bda4832982cd4e9e5b014037